### PR TITLE
Expand changeling biomaterial harvesting targets

### DIFF
--- a/code/__DEFINES/antagonists.dm
+++ b/code/__DEFINES/antagonists.dm
@@ -13,6 +13,20 @@
 /// Min players requireed for nukes to declare war
 #define CHALLENGE_MIN_PLAYERS 50
 
+// Changeling biomaterial inventory defines
+#define CHANGELING_BIOMATERIAL_CATEGORY_PREDATORY "predatory"
+#define CHANGELING_BIOMATERIAL_CATEGORY_ADAPTIVE "adaptive"
+#define CHANGELING_BIOMATERIAL_CATEGORY_RESILIENCE "resilience"
+
+#define CHANGELING_HARVEST_CATEGORY "category"
+#define CHANGELING_HARVEST_ID "id"
+#define CHANGELING_HARVEST_NAME "name"
+#define CHANGELING_HARVEST_DESCRIPTION "description"
+#define CHANGELING_HARVEST_AMOUNT "amount"
+#define CHANGELING_HARVEST_CELL_DEFINE "cell_define"
+#define CHANGELING_HARVEST_SIGNATURE "signature"
+#define CHANGELING_HARVEST_QUALITY "quality"
+
 //fugitive end results
 #define FUGITIVE_RESULT_BADASS_HUNTER 0
 #define FUGITIVE_RESULT_POSTMORTEM_HUNTER 1

--- a/code/modules/antagonists/changeling/powers/absorb.dm
+++ b/code/modules/antagonists/changeling/powers/absorb.dm
@@ -1,162 +1,79 @@
 /datum/action/changeling/absorb_dna
-	name = "Absorb DNA"
-	desc = "Absorb the DNA of our victim. Requires us to strangle them."
-	button_icon_state = "absorb_dna"
-	chemical_cost = 0
-	dna_cost = CHANGELING_POWER_INNATE
-	req_human = TRUE
-	///if we're currently absorbing, used for sanity
-	var/is_absorbing = FALSE
-	var/datum/looping_sound/changeling_absorb/absorbing_loop
+        name = "Harvest Biomass"
+        desc = "Siphon living biomaterial and genetic data from a restrained victim."
+        helptext = "Requires a firm grip on the target, but no longer demands a lethal choke."
+        button_icon_state = "absorb_dna"
+        chemical_cost = 0
+        dna_cost = CHANGELING_POWER_INNATE
+        req_human = TRUE
+        /// Prevents overlapping harvest attempts.
+        var/is_harvesting = FALSE
+        /// Duration of the extraction sequence.
+        var/harvest_time = 10 SECONDS
 
 /datum/action/changeling/absorb_dna/can_sting(mob/living/carbon/owner)
-	if(!..())
-		return
+        if(!..())
+                return
 
-	if(is_absorbing)
-		owner.balloon_alert(owner, "already absorbing!")
-		return
+        if(is_harvesting)
+                owner.balloon_alert(owner, "already harvesting!")
+                return
 
-	if(!owner.pulling || !iscarbon(owner.pulling))
-		owner.balloon_alert(owner, "needs grab!")
-		return
-	if(owner.grab_state <= GRAB_NECK)
-		owner.balloon_alert(owner, "needs tighter grip!")
-		return
+        if(!owner.pulling || !iscarbon(owner.pulling))
+                owner.balloon_alert(owner, "needs grab!")
+                return
 
-	var/mob/living/carbon/target = owner.pulling
-	var/datum/antagonist/changeling/changeling = IS_CHANGELING(owner)
-	return changeling.can_absorb_dna(target)
+        if(owner.grab_state < GRAB_AGGRESSIVE)
+                owner.balloon_alert(owner, "tighten grip!")
+                return
 
-/datum/action/changeling/absorb_dna/sting_action(mob/owner)
-	SHOULD_CALL_PARENT(FALSE) // the only reason to call parent is for proper blackbox logging, and we do that ourselves in a snowflake way
+        var/mob/living/carbon/human/target = owner.pulling
+        var/datum/antagonist/changeling/changeling = IS_CHANGELING(owner)
+        if(!changeling.can_harvest_biomaterials(target))
+                return
+        return changeling.can_absorb_dna(target)
 
-	var/datum/antagonist/changeling/changeling = IS_CHANGELING(owner)
-	var/mob/living/carbon/human/target = owner.pulling
-	is_absorbing = TRUE
+/datum/action/changeling/absorb_dna/sting_action(mob/living/carbon/owner)
+        SHOULD_CALL_PARENT(FALSE)
 
-	if(!attempt_absorb(target))
-		return
+        var/datum/antagonist/changeling/changeling = IS_CHANGELING(owner)
+        var/mob/living/carbon/human/target = owner.pulling
+        if(!target)
+                return FALSE
 
-	SSblackbox.record_feedback("nested tally", "changeling_powers", 1, list("Absorb DNA", "4"))
-	owner.visible_message(span_danger("[owner] sucks the fluids from [target]!"), span_notice("We have absorbed [target]."))
-	to_chat(target, span_userdanger("You are absorbed by the changeling!"))
+        is_harvesting = TRUE
+        owner.visible_message(span_warning("[owner] unfurls slender proboscises into [target]!"), span_notice("We begin extracting living biomaterial from [target]."))
+        to_chat(target, span_userdanger("You feel invasive spines piercing your flesh as cells are siphoned away!"))
 
-	var/true_absorbtion = (!isnull(target.client) || !isnull(target.mind) || !isnull(target.last_mind))
-	if (!true_absorbtion)
-		to_chat(owner, span_changeling(span_bold("You absorb [target], but their weak DNA is not enough to satisfy your hunger.")))
+        if(!do_after(owner, harvest_time, target, hidden = TRUE))
+                owner.balloon_alert(owner, "interrupted!")
+                is_harvesting = FALSE
+                return FALSE
 
-	if(!changeling.has_profile_with_dna(target.dna))
-		changeling.add_new_profile(target)
-		if (true_absorbtion)
-			changeling.true_absorbs++
+        if(owner.pulling != target || owner.grab_state < GRAB_AGGRESSIVE)
+                owner.balloon_alert(owner, "lost control!")
+                is_harvesting = FALSE
+                return FALSE
 
-	if(owner.nutrition < NUTRITION_LEVEL_WELL_FED)
-		owner.set_nutrition(min((owner.nutrition + target.nutrition), NUTRITION_LEVEL_WELL_FED))
+        var/list/results = changeling.harvest_biomaterials_from_mob(target)
+        if(!LAZYLEN(results))
+                owner.balloon_alert(owner, "no viable cells!")
+                is_harvesting = FALSE
+                return FALSE
 
-	// Absorb a lizard, speak Draconic.
-	owner.copy_languages(target, LANGUAGE_ABSORB)
+        var/summary = changeling.build_harvest_summary(results)
+        owner.visible_message(span_notice("[owner] drains a slurry of tissue from [target]!"), span_notice("We extract [summary]."))
+        to_chat(target, span_warning("A wave of fatigue follows the extraction."))
 
-	if(target.mind && owner.mind)//if the victim and owner have minds
-		absorb_memories(target)
+        if(!changeling.has_profile_with_dna(target.dna))
+                changeling.add_new_profile(target)
+        owner.copy_languages(target, LANGUAGE_ABSORB)
 
-	qdel(absorbing_loop)
-	is_absorbing = FALSE
+        changeling.absorbed_count++
+        changeling.true_absorbs++
 
-	changeling.adjust_chemicals(10)
-	if (true_absorbtion)
-		changeling.can_respec++
+        SSblackbox.record_feedback("nested tally", "changeling_powers", 1, list("Harvest Biomass", "1"))
+        log_combat(owner, target, "harvested", object = "biomaterial harvest", addition = summary)
 
-	if(target.stat != DEAD)
-		target.investigate_log("has died from being changeling absorbed.", INVESTIGATE_DEATHS)
-	target.death(FALSE)
-	target.Drain()
-	return TRUE
-
-/datum/action/changeling/absorb_dna/proc/absorb_memories(mob/living/carbon/human/target)
-	var/datum/mind/suckedbrain = target.mind
-
-	var/datum/antagonist/changeling/changeling = IS_CHANGELING(owner)
-
-	for(var/memory_type in suckedbrain.memories)
-		var/datum/memory/stolen_memory = suckedbrain.memories[memory_type]
-		changeling.stolen_memories[stolen_memory.name] = stolen_memory.generate_story(STORY_CHANGELING_ABSORB, STORY_FLAG_NO_STYLE)
-	suckedbrain.wipe_memory()
-
-	for(var/datum/antagonist/antagonist_datum as anything in suckedbrain.antag_datums)
-		var/list/all_objectives = antagonist_datum.objectives.Copy()
-		if(antagonist_datum.antag_memory)
-			changeling.antag_memory += "[target]'s antagonist memories: [antagonist_datum.antag_memory]."
-		if(!LAZYLEN(all_objectives))
-			continue
-		changeling.antag_memory += " Objectives:"
-		var/obj_count = 1
-		for(var/datum/objective/objective as anything in all_objectives)
-			if(!objective) //nulls? in my objective list? it's more likely than you think.
-				continue
-			changeling.antag_memory += " Objective #[obj_count++]: [objective.explanation_text]."
-			var/list/datum/mind/other_owners = objective.get_owners() - suckedbrain
-			if(!other_owners.len)
-				continue
-			for(var/datum/mind/conspirator as anything in other_owners)
-				changeling.antag_memory += " Objective Conspirator: [conspirator.name]."
-	changeling.antag_memory += " That's all [target] had. "
-
-	//Some of target's recent speech, so the changeling can attempt to imitate them better.
-	//Recent as opposed to all because rounds tend to have a LOT of text.
-
-	var/list/recent_speech = target.copy_recent_speech()
-
-	if(recent_speech.len)
-		changeling.antag_memory += "Some of [target]'s speech patterns, we should study these to better impersonate [target.p_them()]: "
-		to_chat(owner, span_boldnotice("Some of [target]'s speech patterns, we should study these to better impersonate [target.p_them()]!"))
-		for(var/spoken_memory in recent_speech)
-			changeling.antag_memory += " \"[spoken_memory]\""
-			to_chat(owner, span_notice("\"[spoken_memory]\""))
-		changeling.antag_memory += ". We have no more knowledge of [target]'s speech patterns. "
-		to_chat(owner, span_boldnotice("We have no more knowledge of [target]'s speech patterns."))
-
-
-	var/datum/antagonist/changeling/target_ling = IS_CHANGELING(target)
-	if(target_ling)//If the target was a changeling, suck out their extra juice and objective points!
-		to_chat(owner, span_boldnotice("[target] was one of us. We have absorbed their power."))
-
-		// Gain half of their genetic points.
-		var/genetic_points_to_add = round(target_ling.total_genetic_points / 2)
-		changeling.genetic_points += genetic_points_to_add
-		changeling.total_genetic_points += genetic_points_to_add
-
-		// And half of their chemical charges.
-		var/chems_to_add = round(target_ling.total_chem_storage / 2)
-		changeling.adjust_chemicals(chems_to_add)
-		changeling.total_chem_storage += chems_to_add
-
-		// And of course however many they've absorbed, we've absorbed
-		changeling.absorbed_count += target_ling.absorbed_count
-
-		// Lastly, make them not a ling anymore. (But leave their objectives for round-end purposes).
-		var/list/copied_objectives = target_ling.objectives.Copy()
-		target.mind.remove_antag_datum(/datum/antagonist/changeling)
-		var/datum/antagonist/fallen_changeling/fallen = target.mind.add_antag_datum(/datum/antagonist/fallen_changeling)
-		fallen.objectives = copied_objectives
-
-/datum/action/changeling/absorb_dna/proc/attempt_absorb(mob/living/carbon/human/target)
-	for(var/absorbing_iteration in 1 to 3)
-		switch(absorbing_iteration)
-			if(1)
-				to_chat(owner, span_notice("This creature is compatible. We must hold still..."))
-			if(2)
-				owner.visible_message(span_warning("[owner] extends a proboscis!"), span_notice("We extend a proboscis."))
-			if(3)
-				absorbing_loop = new(owner, start_immediately = TRUE)
-				owner.visible_message(span_danger("[owner] stabs [target] with the proboscis!"), span_notice("We stab [target] with the proboscis."))
-				to_chat(target, span_userdanger("You feel a sharp stabbing pain!"))
-				target.take_overall_damage(40)
-
-		SSblackbox.record_feedback("nested tally", "changeling_powers", 1, list("Absorb DNA", "[absorbing_iteration]"))
-		if(!do_after(owner, 15 SECONDS, target, hidden = TRUE))
-			owner.balloon_alert(owner, "interrupted!")
-			qdel(absorbing_loop)
-			is_absorbing = FALSE
-			return FALSE
-	return TRUE
+        is_harvesting = FALSE
+        return TRUE

--- a/code/modules/antagonists/changeling/powers/harvest_surface.dm
+++ b/code/modules/antagonists/changeling/powers/harvest_surface.dm
@@ -1,0 +1,45 @@
+/datum/action/changeling/sting/harvest_environment
+        name = "Harvest Environment"
+        desc = "Draws cytology samples from residue, surfaces, and simple organisms."
+        helptext = "Use on swabbable surfaces or cultures to add their biomaterial to our stores."
+        button_icon_state = "sting_extract"
+        chemical_cost = 0
+        dna_cost = CHANGELING_POWER_INNATE
+        req_human = TRUE
+        disabled_by_fire = FALSE
+        var/harvest_time = 5 SECONDS
+
+/datum/action/changeling/sting/harvest_environment/can_sting(mob/living/user, atom/target)
+        if(!..())
+                return
+        if(!target || target == user)
+                return
+        if(!user.Adjacent(target))
+                user.balloon_alert(user, "get closer!")
+                return
+        return TRUE
+
+/datum/action/changeling/sting/harvest_environment/sting_action(mob/living/user, atom/target)
+        var/datum/antagonist/changeling/changeling = IS_CHANGELING(user)
+        if(!changeling)
+                return FALSE
+
+        if(!do_after(user, harvest_time, target, hidden = TRUE))
+                user.balloon_alert(user, "interrupted!")
+                return FALSE
+
+        var/list/samples = list()
+        var/result = SEND_SIGNAL(target, COMSIG_SWAB_FOR_SAMPLES, samples)
+        if(!(result & COMPONENT_SWAB_FOUND) || !LAZYLEN(samples))
+                user.balloon_alert(user, "sterile!")
+                return FALSE
+
+        var/list/harvested = changeling.harvest_biomaterials_from_samples(samples, target)
+        if(!LAZYLEN(harvested))
+                user.balloon_alert(user, "sterile!")
+                return FALSE
+
+var/summary = changeling.build_harvest_summary(harvested)
+user.visible_message(span_notice("[user] collects biological residue from [target]!"), span_notice("We gather [summary]."))
+        SSblackbox.record_feedback("nested tally", "changeling_powers", 1, list("Harvest Environment", "1"))
+        return TRUE

--- a/code/modules/mob/living/basic/farm_animals/chicken/chicken.dm
+++ b/code/modules/mob/living/basic/farm_animals/chicken/chicken.dm
@@ -16,6 +16,15 @@ GLOBAL_VAR_INIT(chicken_count, 0)
 	icon_dead = "chicken_brown_dead"
 	density = FALSE
 	butcher_results = list(/obj/item/food/meat/slab/chicken = 2)
+	changeling_biomaterial_profile = list(
+		list(
+			CHANGELING_HARVEST_CATEGORY = CHANGELING_BIOMATERIAL_CATEGORY_ADAPTIVE,
+			CHANGELING_HARVEST_ID = "avian_quill_cells",
+			CHANGELING_HARVEST_NAME = "Avian Quill Cells",
+			CHANGELING_HARVEST_DESCRIPTION = "Feather follicle cultures steeped in rapid growth hormones.",
+			CHANGELING_HARVEST_AMOUNT = 1,
+		),
+	)
 	response_help_continuous = "pets"
 	response_help_simple = "pet"
 	response_disarm_continuous = "gently pushes aside"

--- a/code/modules/mob/living/basic/farm_animals/cow/_cow.dm
+++ b/code/modules/mob/living/basic/farm_animals/cow/_cow.dm
@@ -12,6 +12,15 @@
 	speak_emote = list("moos","moos hauntingly")
 	speed = 1.1
 	butcher_results = list(/obj/item/food/meat/slab/grassfed = 6)
+	changeling_biomaterial_profile = list(
+		list(
+			CHANGELING_HARVEST_CATEGORY = CHANGELING_BIOMATERIAL_CATEGORY_RESILIENCE,
+			CHANGELING_HARVEST_ID = "bovine_myocytes",
+			CHANGELING_HARVEST_NAME = "Bovine Myocytes",
+			CHANGELING_HARVEST_DESCRIPTION = "Dense ruminant muscle fibers ideal for reinforcing bulk biomass stores.",
+			CHANGELING_HARVEST_AMOUNT = 1,
+		),
+	)
 	response_help_continuous = "pets"
 	response_help_simple = "pet"
 	response_disarm_continuous = "gently pushes aside"

--- a/code/modules/mob/living/basic/vermin/mouse.dm
+++ b/code/modules/mob/living/basic/vermin/mouse.dm
@@ -17,6 +17,15 @@
 	gold_core_spawnable = FRIENDLY_SPAWN
 	faction = list(FACTION_RAT, FACTION_MAINT_CREATURES)
 	butcher_results = list(/obj/item/food/meat/slab/mouse = 1)
+	changeling_biomaterial_profile = list(
+		list(
+			CHANGELING_HARVEST_CATEGORY = CHANGELING_BIOMATERIAL_CATEGORY_ADAPTIVE,
+			CHANGELING_HARVEST_ID = "rodent_neurotissue",
+			CHANGELING_HARVEST_NAME = "Rodent Neurotissue",
+			CHANGELING_HARVEST_DESCRIPTION = "Quick-firing synaptic cultures harvested from opportunistic vermin.",
+			CHANGELING_HARVEST_AMOUNT = 1,
+		),
+	)
 
 	speak_emote = list("squeaks")
 	response_help_continuous = "pets"

--- a/code/modules/mob/living/carbon/human/species_types/ethereal.dm
+++ b/code/modules/mob/living/carbon/human/species_types/ethereal.dm
@@ -18,6 +18,16 @@
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_PRIDE | MIRROR_MAGIC | RACE_SWAP | ERT_SPAWN | SLIME_EXTRACT
 	species_cookie = /obj/item/food/energybar
 	species_language_holder = /datum/language_holder/ethereal
+	changeling_biomaterial_profile = list(
+		list(
+			CHANGELING_HARVEST_CATEGORY = CHANGELING_BIOMATERIAL_CATEGORY_ADAPTIVE,
+			CHANGELING_HARVEST_ID = "ethereal_plasma_lattice",
+			CHANGELING_HARVEST_NAME = "Ethereal Plasma Lattice",
+			CHANGELING_HARVEST_DESCRIPTION = "Ionized tissue matrix pulsing with stored radiation.",
+			CHANGELING_HARVEST_AMOUNT = 1,
+			CHANGELING_HARVEST_SIGNATURE = TRUE,
+		),
+	)
 	sexes = FALSE //no fetish content allowed
 	// Body temperature for ethereals is much higher than humans as they like hotter environments
 	bodytemp_normal = (BODYTEMP_NORMAL + 50)

--- a/code/modules/mob/living/carbon/human/species_types/felinid.dm
+++ b/code/modules/mob/living/carbon/human/species_types/felinid.dm
@@ -21,6 +21,16 @@
 	species_language_holder = /datum/language_holder/felinid
 	payday_modifier = 1.0
 	family_heirlooms = list(/obj/item/toy/cattoy)
+	changeling_biomaterial_profile = list(
+		list(
+			CHANGELING_HARVEST_CATEGORY = CHANGELING_BIOMATERIAL_CATEGORY_PREDATORY,
+			CHANGELING_HARVEST_ID = "felinid_myofibrils",
+			CHANGELING_HARVEST_NAME = "Felinid Myofibrils",
+			CHANGELING_HARVEST_DESCRIPTION = "Hyperresponsive muscle fibers adapted for precise pounces.",
+			CHANGELING_HARVEST_AMOUNT = 1,
+			CHANGELING_HARVEST_SIGNATURE = TRUE,
+		),
+	)
 	/// When false, this is a felinid created by mass-purrbation
 	var/original_felinid = TRUE
 	/// Yummy!

--- a/code/modules/mob/living/carbon/human/species_types/flypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/flypeople.dm
@@ -7,6 +7,16 @@
 	mutanteyes = /obj/item/organ/eyes/fly
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_PRIDE | MIRROR_MAGIC | RACE_SWAP | ERT_SPAWN | SLIME_EXTRACT
 	species_language_holder = /datum/language_holder/fly
+	changeling_biomaterial_profile = list(
+		list(
+			CHANGELING_HARVEST_CATEGORY = CHANGELING_BIOMATERIAL_CATEGORY_PREDATORY,
+			CHANGELING_HARVEST_ID = "fly_chitinous_cells",
+			CHANGELING_HARVEST_NAME = "Chitinous Predator Cells",
+			CHANGELING_HARVEST_DESCRIPTION = "Aggressive insectoid tissue laced with digestive enzymes and irritants.",
+			CHANGELING_HARVEST_AMOUNT = 1,
+			CHANGELING_HARVEST_SIGNATURE = TRUE,
+		),
+	)
 	payday_modifier = 1.0
 
 	mutanttongue = /obj/item/organ/tongue/fly

--- a/code/modules/mob/living/carbon/human/species_types/humans.dm
+++ b/code/modules/mob/living/carbon/human/species_types/humans.dm
@@ -1,12 +1,22 @@
 /datum/species/human
-	name = "\improper Human"
-	id = SPECIES_HUMAN
-	inherent_traits = list(
-		TRAIT_USES_SKINTONES,
-	)
-	skinned_type = /obj/item/stack/sheet/animalhide/human
-	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT
-	payday_modifier = 1.1
+        name = "\improper Human"
+        id = SPECIES_HUMAN
+        inherent_traits = list(
+                TRAIT_USES_SKINTONES,
+        )
+        skinned_type = /obj/item/stack/sheet/animalhide/human
+        changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT
+        payday_modifier = 1.1
+        changeling_biomaterial_profile = list(
+                list(
+                        CHANGELING_HARVEST_CATEGORY = CHANGELING_BIOMATERIAL_CATEGORY_ADAPTIVE,
+                        CHANGELING_HARVEST_ID = "human_cytoplasm",
+                        CHANGELING_HARVEST_NAME = "Human Stem Cells",
+                        CHANGELING_HARVEST_DESCRIPTION = "Baseline cytology culture containing adaptable human stem cells.",
+                        CHANGELING_HARVEST_AMOUNT = 1,
+                        CHANGELING_HARVEST_SIGNATURE = TRUE,
+                ),
+        )
 
 /datum/species/human/prepare_human_for_preview(mob/living/carbon/human/human)
 	human.set_haircolor("#bb9966", update = FALSE) // brown

--- a/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
@@ -29,6 +29,16 @@
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_PRIDE | MIRROR_MAGIC | RACE_SWAP | ERT_SPAWN | SLIME_EXTRACT
 	inherent_factions = list(FACTION_SLIME)
 	species_language_holder = /datum/language_holder/jelly
+	changeling_biomaterial_profile = list(
+		list(
+			CHANGELING_HARVEST_CATEGORY = CHANGELING_BIOMATERIAL_CATEGORY_RESILIENCE,
+			CHANGELING_HARVEST_ID = "jelly_vacuole_sample",
+			CHANGELING_HARVEST_NAME = "Jelly Vacuole Sample",
+			CHANGELING_HARVEST_DESCRIPTION = "Stabilized cytoplasm drawn from an amorphous jelly physiology.",
+			CHANGELING_HARVEST_AMOUNT = 1,
+			CHANGELING_HARVEST_SIGNATURE = TRUE,
+		),
+	)
 	hair_color_mode = USE_MUTANT_COLOR
 	hair_alpha = 150
 	facial_hair_alpha = 150

--- a/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
@@ -26,14 +26,24 @@
 	heatmod = 0.67
 	payday_modifier = 1.0
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_PRIDE | MIRROR_MAGIC | RACE_SWAP | ERT_SPAWN | SLIME_EXTRACT
-	species_cookie = /obj/item/food/meat/slab
-	meat = /obj/item/food/meat/slab/human/mutant/lizard
-	skinned_type = /obj/item/stack/sheet/animalhide/lizard
-	exotic_bloodtype = BLOOD_TYPE_LIZARD
-	inert_mutation = /datum/mutation/firebreath
-	death_sound = 'sound/mobs/humanoids/lizard/deathsound.ogg'
-	species_language_holder = /datum/language_holder/lizard
-	digitigrade_customization = DIGITIGRADE_OPTIONAL
+        species_cookie = /obj/item/food/meat/slab
+        meat = /obj/item/food/meat/slab/human/mutant/lizard
+        skinned_type = /obj/item/stack/sheet/animalhide/lizard
+        exotic_bloodtype = BLOOD_TYPE_LIZARD
+        inert_mutation = /datum/mutation/firebreath
+        death_sound = 'sound/mobs/humanoids/lizard/deathsound.ogg'
+        species_language_holder = /datum/language_holder/lizard
+        digitigrade_customization = DIGITIGRADE_OPTIONAL
+        changeling_biomaterial_profile = list(
+                list(
+                        CHANGELING_HARVEST_CATEGORY = CHANGELING_BIOMATERIAL_CATEGORY_PREDATORY,
+                        CHANGELING_HARVEST_ID = "lizard_chondrocytes",
+                        CHANGELING_HARVEST_NAME = "Reptilian Chondrocytes",
+                        CHANGELING_HARVEST_DESCRIPTION = "Aggressive cytology sample suffused with resilient reptilian tissue.",
+                        CHANGELING_HARVEST_AMOUNT = 1,
+                        CHANGELING_HARVEST_SIGNATURE = TRUE,
+                ),
+        )
 
 	// Lizards are coldblooded and can stand a greater temperature range than humans
 	bodytemp_heat_damage_limit = BODYTEMP_HEAT_LAVALAND_SAFE

--- a/code/modules/mob/living/carbon/human/species_types/monkeys.dm
+++ b/code/modules/mob/living/carbon/human/species_types/monkeys.dm
@@ -25,6 +25,16 @@
 	inherent_factions = list(FACTION_MONKEY)
 	sexes = FALSE
 	species_language_holder = /datum/language_holder/monkey
+	changeling_biomaterial_profile = list(
+		list(
+			CHANGELING_HARVEST_CATEGORY = CHANGELING_BIOMATERIAL_CATEGORY_ADAPTIVE,
+			CHANGELING_HARVEST_ID = "primate_stem_cells",
+			CHANGELING_HARVEST_NAME = "Primate Stem Cells",
+			CHANGELING_HARVEST_DESCRIPTION = "Mutable primate cultures brimming with evolutionary potential.",
+			CHANGELING_HARVEST_AMOUNT = 1,
+			CHANGELING_HARVEST_SIGNATURE = TRUE,
+		),
+	)
 
 	bodypart_overrides = list(
 		BODY_ZONE_L_ARM = /obj/item/bodypart/arm/left/monkey,

--- a/code/modules/mob/living/carbon/human/species_types/mothmen.dm
+++ b/code/modules/mob/living/carbon/human/species_types/mothmen.dm
@@ -18,15 +18,25 @@
 	mutanteyes = /obj/item/organ/eyes/moth
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT
 	species_cookie = /obj/item/food/muffin/moffin
-	species_language_holder = /datum/language_holder/moth
-	death_sound = 'sound/mobs/humanoids/moth/moth_death.ogg'
-	payday_modifier = 1.0
-	family_heirlooms = list(/obj/item/flashlight/lantern/heirloom_moth)
+        species_language_holder = /datum/language_holder/moth
+        death_sound = 'sound/mobs/humanoids/moth/moth_death.ogg'
+        payday_modifier = 1.0
+        family_heirlooms = list(/obj/item/flashlight/lantern/heirloom_moth)
+        changeling_biomaterial_profile = list(
+                list(
+                        CHANGELING_HARVEST_CATEGORY = CHANGELING_BIOMATERIAL_CATEGORY_RESILIENCE,
+                        CHANGELING_HARVEST_ID = "moth_cytoplasm",
+                        CHANGELING_HARVEST_NAME = "Lepidopteran Cytoplasm",
+                        CHANGELING_HARVEST_DESCRIPTION = "Fibrous sample drawn from adaptable mothperson tissues.",
+                        CHANGELING_HARVEST_AMOUNT = 1,
+                        CHANGELING_HARVEST_SIGNATURE = TRUE,
+                ),
+        )
 
-	bodypart_overrides = list(
-		BODY_ZONE_HEAD = /obj/item/bodypart/head/moth,
-		BODY_ZONE_CHEST = /obj/item/bodypart/chest/moth,
-		BODY_ZONE_L_ARM = /obj/item/bodypart/arm/left/moth,
+        bodypart_overrides = list(
+                BODY_ZONE_HEAD = /obj/item/bodypart/head/moth,
+                BODY_ZONE_CHEST = /obj/item/bodypart/chest/moth,
+                BODY_ZONE_L_ARM = /obj/item/bodypart/arm/left/moth,
 		BODY_ZONE_R_ARM = /obj/item/bodypart/arm/right/moth,
 		BODY_ZONE_L_LEG = /obj/item/bodypart/leg/left/moth,
 		BODY_ZONE_R_LEG = /obj/item/bodypart/leg/right/moth,

--- a/code/modules/mob/living/carbon/human/species_types/plasmamen.dm
+++ b/code/modules/mob/living/carbon/human/species_types/plasmamen.dm
@@ -33,6 +33,16 @@
 	species_cookie = /obj/item/reagent_containers/condiment/milk
 	outfit_important_for_life = /datum/outfit/plasmaman
 	species_language_holder = /datum/language_holder/skeleton
+	changeling_biomaterial_profile = list(
+		list(
+			CHANGELING_HARVEST_CATEGORY = CHANGELING_BIOMATERIAL_CATEGORY_RESILIENCE,
+			CHANGELING_HARVEST_ID = "plasmaman_colonids",
+			CHANGELING_HARVEST_NAME = "Plasmaman Colonid Matrix",
+			CHANGELING_HARVEST_DESCRIPTION = "Fungal biomatter binding to an exoskeletal frame and suffused with plasma energy.",
+			CHANGELING_HARVEST_AMOUNT = 1,
+			CHANGELING_HARVEST_SIGNATURE = TRUE,
+		),
+	)
 
 	bodypart_overrides = list(
 		BODY_ZONE_L_ARM = /obj/item/bodypart/arm/left/plasmaman,

--- a/code/modules/mob/living/carbon/human/species_types/podpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/podpeople.dm
@@ -19,6 +19,16 @@
 	exotic_bloodtype = BLOOD_TYPE_H2O
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | RACE_SWAP | ERT_SPAWN | SLIME_EXTRACT
 	species_language_holder = /datum/language_holder/plant
+	changeling_biomaterial_profile = list(
+		list(
+			CHANGELING_HARVEST_CATEGORY = CHANGELING_BIOMATERIAL_CATEGORY_RESILIENCE,
+			CHANGELING_HARVEST_ID = "pod_chloroplast_matrix",
+			CHANGELING_HARVEST_NAME = "Chloroplast Matrix",
+			CHANGELING_HARVEST_DESCRIPTION = "Photosynthetic tissues saturated with regenerative plant growth factors.",
+			CHANGELING_HARVEST_AMOUNT = 1,
+			CHANGELING_HARVEST_SIGNATURE = TRUE,
+		),
+	)
 
 	mutantappendix = /obj/item/organ/appendix/pod
 	mutantbrain = /obj/item/organ/brain/pod

--- a/code/modules/mob/living/carbon/human/species_types/snail.dm
+++ b/code/modules/mob/living/carbon/human/species_types/snail.dm
@@ -18,6 +18,16 @@
 	mutanttongue = /obj/item/organ/tongue/snail
 	mutantliver = /obj/item/organ/liver/snail
 	exotic_bloodtype = BLOOD_TYPE_SNAIL
+	changeling_biomaterial_profile = list(
+		list(
+			CHANGELING_HARVEST_CATEGORY = CHANGELING_BIOMATERIAL_CATEGORY_RESILIENCE,
+			CHANGELING_HARVEST_ID = "snail_mucosal_cells",
+			CHANGELING_HARVEST_NAME = "Mucosal Resilience Cells",
+			CHANGELING_HARVEST_DESCRIPTION = "Viscoelastic snail tissues rich with hydration-preserving enzymes.",
+			CHANGELING_HARVEST_AMOUNT = 1,
+			CHANGELING_HARVEST_SIGNATURE = TRUE,
+		),
+	)
 
 	bodypart_overrides = list(
 		BODY_ZONE_HEAD = /obj/item/bodypart/head/snail,

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -44,8 +44,33 @@
 		QDEL_LIST(imaginary_group)
 	QDEL_LAZYLIST(diseases)
 	QDEL_LIST(surgeries)
-	QDEL_LIST(quirks)
-	return ..()
+        QDEL_LIST(quirks)
+        return ..()
+
+/mob/living/proc/get_changeling_biomaterial_profile()
+        if(islist(changeling_biomaterial_profile) && LAZYLEN(changeling_biomaterial_profile))
+                var/list/output = list()
+                for(var/list/entry as anything in changeling_biomaterial_profile)
+                        if(!islist(entry))
+                                continue
+                        output += list(entry.Copy())
+                return output
+        return list(generate_default_changeling_profile())
+
+/mob/living/proc/generate_default_changeling_profile()
+        var/display_name = initial(name)
+        if(!istext(display_name) || !length(display_name))
+                display_name = "organism"
+        var/id_seed = changeling_sanitize_material_id(copytext(type2text(type), 6))
+        if(!length(id_seed))
+                id_seed = "biomaterial"
+        return list(
+                CHANGELING_HARVEST_CATEGORY = CHANGELING_BIOMATERIAL_CATEGORY_RESILIENCE,
+                CHANGELING_HARVEST_ID = id_seed,
+                CHANGELING_HARVEST_NAME = "[capitalize(display_name)] Cytology Sample",
+                CHANGELING_HARVEST_DESCRIPTION = "A baseline cellular sample drawn from [display_name].",
+                CHANGELING_HARVEST_AMOUNT = 1,
+        )
 
 /mob/living/onZImpact(turf/impacted_turf, levels, impact_flags = NONE)
 	if(!isgroundlessturf(impacted_turf))

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -88,7 +88,9 @@
 	  */
 	var/incorporeal_move = FALSE
 
-	var/list/quirks = list()
+        var/list/quirks = list()
+        ///Predefined biomaterial yields harvested by changelings.
+        var/list/changeling_biomaterial_profile
 	///a list of surgery datums. generally empty, they're added when the player wants them.
 	var/list/surgeries = list()
 	///Mob specific surgery speed modifier
@@ -127,7 +129,7 @@
 	///How many hands hands does this mob currently have. Should only be changed through set_num_hands()
 	var/num_hands = 2
 	///How many usable hands does this mob currently have. Should only be changed through set_usable_hands()
-	var/usable_hands = 2
+        var/usable_hands = 2
 
 	var/list/pipes_shown = list()
 	var/last_played_vent = 0

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3346,6 +3346,7 @@
 #include "code\modules\antagonists\changeling\fallen_changeling.dm"
 #include "code\modules\antagonists\changeling\headslug_eggs.dm"
 #include "code\modules\antagonists\changeling\powers\absorb.dm"
+#include "code\modules\antagonists\changeling\powers\harvest_surface.dm"
 #include "code\modules\antagonists\changeling\powers\adaptive_wardrobe.dm"
 #include "code\modules\antagonists\changeling\powers\adrenaline.dm"
 #include "code\modules\antagonists\changeling\powers\augmented_eyesight.dm"


### PR DESCRIPTION
## Summary
- add the Harvest Environment innate to swab surfaces and cultures for biomaterial yields
- rework Harvest Biomass and the changeling backend to populate biomaterial inventories instead of hard DNA/chemical rewards
- seed species and simple-mob biomaterial profiles so felinids, ethereals, plasmamen, other races, and livestock provide distinct samples

## Testing
- `python3 tools/validate_dme.py tgstation.dme` *(blocked: script expects DreamMaker include output on stdin)*

------
https://chatgpt.com/codex/tasks/task_e_68cc81214170832a879c446aea8bbe9b