### PR TITLE
Fix Harvest Environment summary message indentation

### DIFF
--- a/code/modules/antagonists/changeling/powers/harvest_surface.dm
+++ b/code/modules/antagonists/changeling/powers/harvest_surface.dm
@@ -39,7 +39,7 @@
                 user.balloon_alert(user, "sterile!")
                 return FALSE
 
-var/summary = changeling.build_harvest_summary(harvested)
-user.visible_message(span_notice("[user] collects biological residue from [target]!"), span_notice("We gather [summary]."))
-        SSblackbox.record_feedback("nested tally", "changeling_powers", 1, list("Harvest Environment", "1"))
+	var/summary = changeling.build_harvest_summary(harvested)
+	user.visible_message(span_notice("[user] collects biological residue from [target]!"), span_notice("We gather [summary]."))
+	SSblackbox.record_feedback("nested tally", "changeling_powers", 1, list("Harvest Environment", "1"))
         return TRUE


### PR DESCRIPTION
## Summary
- ensure the Harvest Environment sting builds its summary and announces the results before logging feedback

## Testing
- `./tools/build/build.sh dm --skip-icon-cutter` *(fails: DreamMaker executable missing in PATH in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ccdc1b5254832aa6de9276e10180da