### PR TITLE
Fix changeling profile type text conversion

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -61,7 +61,7 @@
 	var/display_name = initial(name)
 	if(!istext(display_name) || !length(display_name))
 		display_name = "organism"
-	var/id_seed = changeling_sanitize_material_id(copytext(type2text(type), 6))
+	var/id_seed = changeling_sanitize_material_id(copytext("[type]", 6))
 	if(!length(id_seed))
 		id_seed = "biomaterial"
 	return list(


### PR DESCRIPTION
## Summary
- replace the changeling biomaterial profile seed generation to use copytext on the type string instead of the removed type2text helper

## Testing
- tools/build/build.sh *(fails: network 403 fetching dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68cce4b50394832abb072ab52cd565d1