### PR TITLE
Fix changeling preset deletion message

### DIFF
--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -954,13 +954,14 @@
 /datum/antagonist/changeling/proc/delete_genetic_preset(index)
 	if(!isnum(index))
 		return FALSE
-	if(index < 1 || index > LAZYLEN(genetic_presets))
-		return FALSE
-	var/list/preset = genetic_presets[index]
-	genetic_presets.Cut(index, index + 1)
-	if(owner?.current && preset)
-		to_chat(owner.current, span_notice("We purge the [preset ? preset[\"name\"] : \"lost\"] template."))
-	return TRUE
+        if(index < 1 || index > LAZYLEN(genetic_presets))
+                return FALSE
+        var/list/preset = genetic_presets[index]
+        var/preset_label = preset ? preset["name"] : "lost"
+        genetic_presets.Cut(index, index + 1)
+        if(owner?.current && preset)
+                to_chat(owner.current, span_notice("We purge the [preset_label] template."))
+        return TRUE
 
 /datum/antagonist/changeling/proc/rename_genetic_preset(index, new_name)
 	if(!isnum(index))


### PR DESCRIPTION
## Summary
- compute the deleted preset's label before sending the chat notification
- reuse the preset_label variable in the deletion message to avoid inline ternary lookups

## Testing
- tools/build/build.sh *(fails: HTTP 403 downloading build dependencies in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cce4b6f578832a9940f5ecd4fba76e