### PR TITLE
Move changeling macros into shared header

### DIFF
--- a/code/__DEFINES/changeling.dm
+++ b/code/__DEFINES/changeling.dm
@@ -1,0 +1,8 @@
+/// Identifier used for the active key slot within a changeling's build.
+#define CHANGELING_KEY_BUILD_SLOT "key"
+/// Identifier used for the set of secondary slots within a changeling's build.
+#define CHANGELING_SECONDARY_BUILD_SLOTS "secondary"
+/// Maximum number of secondary slots a changeling can maintain concurrently.
+#define CHANGELING_SECONDARY_SLOT_LIMIT 7
+/// Blueprint payload key used when ingesting crafting data.
+#define CHANGELING_BUILD_BLUEPRINT "build"

--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -1,15 +1,6 @@
 /// Helper to format the text that gets thrown onto the chem hud element.
 #define FORMAT_CHEM_CHARGES_TEXT(charges) MAPTEXT("<div align='center' valign='middle' style='position:relative; top:0px; left:6px'><font color='#dd66dd'>[round(charges)]</font></div>")
 
-/// Identifier used for the active key slot within a changeling's build.
-#define CHANGELING_KEY_BUILD_SLOT "key"
-/// Identifier used for the set of secondary slots within a changeling's build.
-#define CHANGELING_SECONDARY_BUILD_SLOTS "secondary"
-/// Maximum number of secondary slots a changeling can maintain concurrently.
-#define CHANGELING_SECONDARY_SLOT_LIMIT 7
-/// Blueprint payload key used when ingesting crafting data.
-#define CHANGELING_BUILD_BLUEPRINT "build"
-
 /// Normalizes identifiers for biomaterial records.
 /proc/changeling_sanitize_material_id(identifier)
 	if(isnull(identifier))

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -66,6 +66,7 @@
 #include "code\__DEFINES\cameranets.dm"
 #include "code\__DEFINES\cargo.dm"
 #include "code\__DEFINES\chat.dm"
+#include "code\__DEFINES\changeling.dm"
 #include "code\__DEFINES\chat_filter.dm"
 #include "code\__DEFINES\cleaning.dm"
 #include "code\__DEFINES\click.dm"


### PR DESCRIPTION
## Summary
- add code/__DEFINES/changeling.dm with shared CHANGELING_* macros
- include the new changeling defines file in tgstation.dme so both changeling modules can use the macros

## Testing
- DreamMaker tgstation.dme *(fails: DreamMaker is not available in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cce4b5c8d8832ab6d6cf8e9f76787f