### PR TITLE
Remove unused lists from changeling genetic matrix synergy tips

### DIFF
--- a/code/modules/antagonists/changeling/genetic_matrix.dm
+++ b/code/modules/antagonists/changeling/genetic_matrix.dm
@@ -143,8 +143,6 @@
 
 	var/list/low_cost = list()
 	var/list/chem_hungry = list()
-	var/list/absorb_targets = list()
-	var/list/dna_targets = list()
 
 	var/next_absorb_target
 	var/list/next_absorb_names = list()


### PR DESCRIPTION
## Summary
- remove unused absorb and dna target list declarations in the genetic matrix synergy tips builder to eliminate compiler warnings

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cd2d5d9e0c832a8c8f35a079ca4d6d