### PR TITLE
Fix preset payload return indentation

### DIFF
--- a/code/modules/antagonists/changeling/genetic_matrix.dm
+++ b/code/modules/antagonists/changeling/genetic_matrix.dm
@@ -293,7 +293,7 @@
 		output += list(entry)
 		index++
 
-return output
+	return output
 
 /datum/genetic_matrix/proc/get_crafting_recipes()
 	if(islist(GLOB.changeling_crafting_recipes))


### PR DESCRIPTION
## Summary
- align the final `return output` inside the changeling genetic matrix preset payload proc to satisfy DM indentation rules

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cd2d59461c832a8b7947ac450d34dc