### PR TITLE
Add changeling biomaterial profiles to modular species

### DIFF
--- a/modular_nova/modules/customization/modules/mob/living/carbon/human/species/tajaran.dm
+++ b/modular_nova/modules/customization/modules/mob/living/carbon/human/species/tajaran.dm
@@ -25,6 +25,16 @@
 		BODY_ZONE_L_LEG = /obj/item/bodypart/leg/left/mutant,
 		BODY_ZONE_R_LEG = /obj/item/bodypart/leg/right/mutant,
 	)
+	changeling_biomaterial_profile = list(
+		list(
+			CHANGELING_HARVEST_CATEGORY = CHANGELING_BIOMATERIAL_CATEGORY_PREDATORY,
+			CHANGELING_HARVEST_ID = "tajaran_pounce_myocytes",
+			CHANGELING_HARVEST_NAME = "Tajaran Pounce Myocytes",
+			CHANGELING_HARVEST_DESCRIPTION = "Elastic muscle fibers brimming with Tajaran hunter reflexes.",
+			CHANGELING_HARVEST_AMOUNT = 1,
+			CHANGELING_HARVEST_SIGNATURE = TRUE,
+		),
+	)
 
 /datum/species/tajaran/get_default_mutant_bodyparts()
 	return list(

--- a/modular_nova/modules/customization/modules/mob/living/carbon/human/species/vox.dm
+++ b/modular_nova/modules/customization/modules/mob/living/carbon/human/species/vox.dm
@@ -43,6 +43,16 @@
 		LOADOUT_ITEM_MISC = VOX_BACK_ICON,
 		LOADOUT_ITEM_EARS = VOX_EARS_ICON
 	)
+	changeling_biomaterial_profile = list(
+		list(
+			CHANGELING_HARVEST_CATEGORY = CHANGELING_BIOMATERIAL_CATEGORY_ADAPTIVE,
+			CHANGELING_HARVEST_ID = "vox_chorus_culture",
+			CHANGELING_HARVEST_NAME = "Vox Chorus Cytoculture",
+			CHANGELING_HARVEST_DESCRIPTION = "Self-modulating cells tuned to the Vox chorus, ideal for adaptive graftwork.",
+			CHANGELING_HARVEST_AMOUNT = 1,
+			CHANGELING_HARVEST_SIGNATURE = TRUE,
+		),
+	)
 
 /datum/species/vox/get_default_mutant_bodyparts()
 	return list(

--- a/modular_nova/modules/teshari/code/_teshari.dm
+++ b/modular_nova/modules/teshari/code/_teshari.dm
@@ -46,6 +46,16 @@
 		BODY_ZONE_L_LEG = /obj/item/bodypart/leg/left/mutant/teshari,
 		BODY_ZONE_R_LEG = /obj/item/bodypart/leg/right/mutant/teshari,
 	)
+	changeling_biomaterial_profile = list(
+		list(
+			CHANGELING_HARVEST_CATEGORY = CHANGELING_BIOMATERIAL_CATEGORY_RESILIENCE,
+			CHANGELING_HARVEST_ID = "teshari_thermoclinal_cells",
+			CHANGELING_HARVEST_NAME = "Teshari Thermoclinal Cells",
+			CHANGELING_HARVEST_DESCRIPTION = "Frigid-honed cytology sample that keeps a blazing metabolism through any chill.",
+			CHANGELING_HARVEST_AMOUNT = 1,
+			CHANGELING_HARVEST_SIGNATURE = TRUE,
+		),
+	)
 
 /datum/species/teshari/get_default_mutant_bodyparts()
 	return list(


### PR DESCRIPTION
## Summary
- add species-specific changeling biomaterial profiles for modular Vox, Tajaran, and Teshari species
- mark each profile with themed changeling harvest metadata for crafting flavor

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cd35756d5c832ab4c3201da0c7d1a9