### PR TITLE
Add changeling genetic matrix interface

### DIFF
--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -62,12 +62,18 @@
 	/// Whether we can currently respec in the cellular emporium.
 	var/can_respec = 0
 
-	/// The currently active changeling sting.
-	var/datum/action/changeling/sting/chosen_sting
-	/// A reference to our cellular emporium datum.
-	var/datum/cellular_emporium/cellular_emporium
-	/// A reference to our cellular emporium action (which opens the UI for the datum).
-	var/datum/action/cellular_emporium/emporium_action
+        /// The currently active changeling sting.
+        var/datum/action/changeling/sting/chosen_sting
+        /// A reference to our cellular emporium datum.
+        var/datum/cellular_emporium/cellular_emporium
+        /// A reference to our cellular emporium action (which opens the UI for the datum).
+        var/datum/action/cellular_emporium/emporium_action
+        /// Coordinator for the genetic matrix UI.
+        var/datum/genetic_matrix/genetic_matrix
+        /// Action that opens the genetic matrix UI.
+        var/datum/action/changeling/genetic_matrix/genetic_matrix_action
+        /// Builds configured for the genetic matrix.
+        var/list/genetic_matrix_builds
 
 	/// UI displaying how many chems we have
 	var/atom/movable/screen/ling/chems/lingchemdisplay
@@ -116,16 +122,21 @@
 		break
 
 /datum/antagonist/changeling/Destroy()
-	QDEL_NULL(emporium_action)
-	QDEL_NULL(cellular_emporium)
-	current_profile = null
-	return ..()
+        QDEL_NULL(emporium_action)
+        QDEL_NULL(cellular_emporium)
+        QDEL_NULL(genetic_matrix_action)
+        QDEL_NULL(genetic_matrix)
+        QDEL_LIST(genetic_matrix_builds)
+        genetic_matrix_builds = null
+        current_profile = null
+        return ..()
 
 /datum/antagonist/changeling/on_gain()
-	generate_name()
-	create_emporium()
-	create_innate_actions()
-	create_initial_profile()
+        generate_name()
+        create_emporium()
+        create_genetic_matrix()
+        create_innate_actions()
+        create_initial_profile()
 	if(give_objectives)
 		forge_objectives()
 	owner.current.get_language_holder().omnitongue = TRUE
@@ -226,9 +237,18 @@
  * Instantiate the cellular emporium for the changeling.
  */
 /datum/antagonist/changeling/proc/create_emporium()
-	cellular_emporium = new(src)
-	emporium_action = new(cellular_emporium)
-	emporium_action.Grant(owner.current)
+        cellular_emporium = new(src)
+        emporium_action = new(cellular_emporium)
+        emporium_action.Grant(owner.current)
+
+/datum/antagonist/changeling/proc/create_genetic_matrix()
+        QDEL_NULL(genetic_matrix_action)
+        QDEL_NULL(genetic_matrix)
+        genetic_matrix = new(src)
+        genetic_matrix_action = new(genetic_matrix)
+        ensure_genetic_matrix_setup()
+        if(owner && owner.current)
+                genetic_matrix_action.Grant(owner.current)
 
 /*
  * Instantiate all the default actions of a ling (transform, dna sting, absorb, etc)
@@ -337,28 +357,31 @@
  * if [include_innate] = TRUE, will also remove all powers from the Changeling's innate_powers list.
  */
 /datum/antagonist/changeling/proc/remove_changeling_powers(include_innate = FALSE)
-	if(!isliving(owner.current))
-		return
+        if(!isliving(owner.current))
+                return
 
-	if(chosen_sting)
-		chosen_sting.unset_sting(owner.current)
+        if(chosen_sting)
+                chosen_sting.unset_sting(owner.current)
 
-	QDEL_LIST_ASSOC_VAL(purchased_powers)
-	if(include_innate)
-		QDEL_LIST(innate_powers)
+        QDEL_LIST_ASSOC_VAL(purchased_powers)
+        if(include_innate)
+                QDEL_LIST(innate_powers)
 
-	genetic_points = total_genetic_points
-	chem_charges = min(chem_charges, total_chem_storage)
-	chem_recharge_rate = initial(chem_recharge_rate)
-	chem_recharge_slowdown = initial(chem_recharge_slowdown)
+        genetic_points = total_genetic_points
+        chem_charges = min(chem_charges, total_chem_storage)
+        chem_recharge_rate = initial(chem_recharge_rate)
+        chem_recharge_slowdown = initial(chem_recharge_slowdown)
+        prune_genetic_matrix_assignments()
 
 /*
  * For resetting all of the changeling's action buttons. (IE, re-granting them all.)
  */
 /datum/antagonist/changeling/proc/regain_powers()
-	emporium_action.Grant(owner.current)
-	for(var/datum/action/changeling/power as anything in innate_powers)
-		power.on_purchase(owner.current)
+        emporium_action.Grant(owner.current)
+        if(genetic_matrix_action)
+                genetic_matrix_action.Grant(owner.current)
+        for(var/datum/action/changeling/power as anything in innate_powers)
+                power.on_purchase(owner.current)
 
 	for(var/power_path in purchased_powers)
 		var/datum/action/changeling/power = purchased_powers[power_path]
@@ -618,16 +641,17 @@
  * new_profile - the profile being added.
  */
 /datum/antagonist/changeling/proc/add_profile(datum/changeling_profile/new_profile)
-	if(stored_profiles.len > dna_max)
-		if(!push_out_profile())
-			return
+        if(stored_profiles.len > dna_max)
+                if(!push_out_profile())
+                        return
 
-	if(!first_profile)
-		first_profile = new_profile
-		current_profile = first_profile
+        if(!first_profile)
+                first_profile = new_profile
+                current_profile = first_profile
 
-	stored_profiles += new_profile
-	absorbed_count++
+        stored_profiles += new_profile
+        on_genetic_matrix_profile_added(new_profile)
+        absorbed_count++
 
 /*
  * Create a new profile from the given [profile_target]
@@ -648,12 +672,13 @@
  * force - if TRUE, removes the profile even if it's protected.
  */
 /datum/antagonist/changeling/proc/remove_profile(mob/living/carbon/human/profile_target, force = FALSE)
-	for(var/datum/changeling_profile/found_profile as anything in stored_profiles)
-		if(profile_target.real_name == found_profile.name)
-			if(found_profile.protected && !force)
-				continue
-			stored_profiles -= found_profile
-			qdel(found_profile)
+        for(var/datum/changeling_profile/found_profile as anything in stored_profiles)
+                if(profile_target.real_name == found_profile.name)
+                        if(found_profile.protected && !force)
+                                continue
+                        stored_profiles -= found_profile
+                        on_genetic_matrix_profile_removed(found_profile)
+                        qdel(found_profile)
 
 /*
  * Removes the highest changeling profile from the list
@@ -662,16 +687,18 @@
  * Returns TRUE if a profile was removed, FALSE otherwise.
  */
 /datum/antagonist/changeling/proc/push_out_profile()
-	var/datum/changeling_profile/profle_to_remove
-	for(var/datum/changeling_profile/found_profile as anything in stored_profiles)
-		if(!found_profile.protected)
-			profle_to_remove = found_profile
-			break
+        var/datum/changeling_profile/profile_to_remove
+        for(var/datum/changeling_profile/found_profile as anything in stored_profiles)
+                if(!found_profile.protected)
+                        profile_to_remove = found_profile
+                        break
 
-	if(profle_to_remove)
-		stored_profiles -= profle_to_remove
-		return TRUE
-	return FALSE
+        if(profile_to_remove)
+                stored_profiles -= profile_to_remove
+                on_genetic_matrix_profile_removed(profile_to_remove)
+                qdel(profile_to_remove)
+                return TRUE
+        return FALSE
 
 /*
  * Create a profile based on the changeling's initial appearance.

--- a/code/modules/antagonists/changeling/genetic_matrix.dm
+++ b/code/modules/antagonists/changeling/genetic_matrix.dm
@@ -1,0 +1,511 @@
+#define GENETIC_MATRIX_MAX_ABILITY_SLOTS 3
+#define GENETIC_MATRIX_MAX_BUILDS 6
+
+/// Coordinating datum for the changeling genetic matrix interface.
+/datum/genetic_matrix
+  var/name = "Genetic Matrix"
+  var/datum/antagonist/changeling/changeling
+
+/datum/genetic_matrix/New(datum/antagonist/changeling/changeling)
+  . = ..()
+  src.changeling = changeling
+
+/datum/genetic_matrix/Destroy()
+  changeling = null
+  return ..()
+
+/datum/genetic_matrix/ui_state(mob/user)
+  return GLOB.always_state
+
+/datum/genetic_matrix/ui_status(mob/user, datum/ui_state/state)
+  if(!changeling)
+    return UI_CLOSE
+  return UI_INTERACTIVE
+
+/datum/genetic_matrix/ui_interact(mob/user, datum/tgui/ui)
+  ui = SStgui.try_update_ui(user, src, ui)
+  if(!ui)
+    ui = new(user, src, "GeneticMatrix", name)
+    ui.open()
+
+/datum/genetic_matrix/ui_static_data(mob/user)
+  return list(
+    "maxAbilitySlots" = GENETIC_MATRIX_MAX_ABILITY_SLOTS,
+    "maxBuilds" = GENETIC_MATRIX_MAX_BUILDS,
+  )
+
+/datum/genetic_matrix/ui_data(mob/user)
+  var/list/data = list()
+  if(!changeling)
+    return data
+
+  changeling.ensure_genetic_matrix_setup()
+  changeling.prune_genetic_matrix_assignments()
+
+  data["builds"] = changeling.get_genetic_matrix_builds_data()
+  data["resultCatalog"] = changeling.get_genetic_matrix_profile_catalog()
+  data["abilityCatalog"] = changeling.get_genetic_matrix_ability_catalog()
+  data["cells"] = changeling.get_genetic_matrix_profile_storage()
+  data["abilities"] = changeling.get_genetic_matrix_ability_storage()
+  data["skills"] = changeling.get_genetic_matrix_skills_data()
+  data["canAddBuild"] = changeling.genetic_matrix_builds.len < GENETIC_MATRIX_MAX_BUILDS
+  return data
+
+/datum/genetic_matrix/ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)
+  . = ..()
+  if(.)
+    return
+
+  if(!changeling)
+    return FALSE
+
+  var/mob/user = ui.user
+
+  switch(action)
+    if("create_build")
+      if(changeling.genetic_matrix_builds.len >= GENETIC_MATRIX_MAX_BUILDS)
+        return FALSE
+
+      var/default_name = "Matrix Build [changeling.genetic_matrix_builds.len + 1]"
+      var/new_name = tgui_input_text(user, "Name the new build.", "Create Genetic Matrix Build", default_name, 32)
+      if(isnull(new_name))
+        return FALSE
+
+      new_name = sanitize_text(new_name)
+      if(!length(new_name))
+        new_name = default_name
+
+      changeling.add_genetic_matrix_build(new_name)
+      return TRUE
+
+    if("delete_build")
+      var/datum/genetic_matrix_build/build = changeling.find_genetic_matrix_build(params["build"])
+      if(!build)
+        return FALSE
+
+      if(tgui_alert(user, "Delete build \"[build.name]\"?", "Remove Build", list("Delete", "Cancel")) != "Delete")
+        return FALSE
+
+      changeling.remove_genetic_matrix_build(build)
+      return TRUE
+
+    if("rename_build")
+      var/datum/genetic_matrix_build/build = changeling.find_genetic_matrix_build(params["build"])
+      if(!build)
+        return FALSE
+
+      var/new_name = tgui_input_text(user, "Enter a new name for this build.", "Rename Build", build.name, 32)
+      if(isnull(new_name))
+        return FALSE
+
+      new_name = sanitize_text(new_name)
+      if(!length(new_name))
+        return FALSE
+
+      build.name = new_name
+      return TRUE
+
+    if("clear_build")
+      var/datum/genetic_matrix_build/build = changeling.find_genetic_matrix_build(params["build"])
+      if(!build)
+        return FALSE
+
+      changeling.clear_genetic_matrix_build(build)
+      return TRUE
+
+    if("set_build_profile")
+      var/datum/genetic_matrix_build/build = changeling.find_genetic_matrix_build(params["build"])
+      if(!build)
+        return FALSE
+
+      var/datum/changeling_profile/profile = changeling.find_genetic_matrix_profile(params["profile"])
+      changeling.assign_genetic_matrix_profile(build, profile)
+      return TRUE
+
+    if("clear_build_profile")
+      var/datum/genetic_matrix_build/build = changeling.find_genetic_matrix_build(params["build"])
+      if(!build)
+        return FALSE
+
+      changeling.assign_genetic_matrix_profile(build, null)
+      return TRUE
+
+    if("set_build_ability")
+      var/datum/genetic_matrix_build/build = changeling.find_genetic_matrix_build(params["build"])
+      if(!build)
+        return FALSE
+
+      var/slot = clamp(text2num(params["slot"]), 1, GENETIC_MATRIX_MAX_ABILITY_SLOTS)
+      if(!slot)
+        return FALSE
+
+      var/ability_identifier = params["ability"]
+      if(!ability_identifier)
+        changeling.assign_genetic_matrix_ability(build, null, slot)
+        return TRUE
+
+      var/datum/action/changeling/ability_path = text2path(ability_identifier)
+      if(!ispath(ability_path, /datum/action/changeling))
+        return FALSE
+
+      if(!changeling.has_genetic_matrix_ability(ability_path))
+        return FALSE
+
+      changeling.assign_genetic_matrix_ability(build, ability_path, slot)
+      return TRUE
+
+    if("clear_build_ability")
+      var/datum/genetic_matrix_build/build = changeling.find_genetic_matrix_build(params["build"])
+      if(!build)
+        return FALSE
+
+      var/slot = clamp(text2num(params["slot"]), 1, GENETIC_MATRIX_MAX_ABILITY_SLOTS)
+      if(!slot)
+        return FALSE
+
+      changeling.assign_genetic_matrix_ability(build, null, slot)
+      return TRUE
+
+  return FALSE
+
+/// Individual configuration of a matrix build.
+/datum/genetic_matrix_build
+  /// Owning changeling datum.
+  var/datum/antagonist/changeling/changeling
+  /// Player-facing name.
+  var/name = "Matrix Build"
+  /// DNA profile assigned to this build, if any.
+  var/datum/changeling_profile/assigned_profile
+  /// List of ability paths assigned to slots.
+  var/list/ability_paths = list()
+
+/datum/genetic_matrix_build/New(datum/antagonist/changeling/changeling_owner)
+  . = ..()
+  changeling = changeling_owner
+
+/datum/genetic_matrix_build/Destroy()
+  assigned_profile = null
+  ability_paths = null
+  changeling = null
+  return ..()
+
+/datum/genetic_matrix_build/proc/ensure_slot_capacity()
+  while(ability_paths.len < GENETIC_MATRIX_MAX_ABILITY_SLOTS)
+    ability_paths += null
+
+/datum/genetic_matrix_build/proc/to_data()
+  var/list/data = list(
+    "id" = REF(src),
+    "name" = name,
+  )
+
+  if(changeling && assigned_profile && (assigned_profile in changeling.stored_profiles))
+    data["profile"] = changeling.get_genetic_matrix_profile_data(assigned_profile)
+  else
+    data["profile"] = null
+
+  ensure_slot_capacity()
+
+  var/list/ability_data = list()
+  for(var/i in 1 to GENETIC_MATRIX_MAX_ABILITY_SLOTS)
+    var/path = ability_paths[i]
+    if(!path || !changeling || !changeling.has_genetic_matrix_ability(path))
+      ability_paths[i] = null
+      ability_data += list(null)
+      continue
+
+    var/list/ability_entry = changeling.get_genetic_matrix_ability_data(path)
+    ability_entry["slot"] = i
+    ability_data += list(ability_entry)
+
+  data["abilities"] = ability_data
+  return data
+
+/datum/action/changeling/genetic_matrix
+  name = "Genetic Matrix"
+  button_icon_state = "sting_transform"
+  background_icon_state = "bg_changeling"
+  overlay_icon_state = "bg_changeling_border"
+  check_flags = NONE
+
+/datum/action/changeling/genetic_matrix/New(Target)
+  . = ..()
+  if(!istype(Target, /datum/genetic_matrix))
+    stack_trace("genetic_matrix action created with non-matrix target.")
+    qdel(src)
+
+/datum/action/changeling/genetic_matrix/Trigger(mob/clicker, trigger_flags)
+  . = ..()
+  if(!.)
+    return
+
+  var/datum/genetic_matrix/matrix = target
+  matrix.ui_interact(owner)
+
+/// Ensure that the matrix data structures exist and have at least one build configured.
+/datum/antagonist/changeling/proc/ensure_genetic_matrix_setup()
+  if(!genetic_matrix_builds)
+    genetic_matrix_builds = list()
+
+  if(!genetic_matrix_builds.len)
+    add_genetic_matrix_build("Matrix Build 1")
+
+/// Remove invalid references from matrix builds.
+/datum/antagonist/changeling/proc/prune_genetic_matrix_assignments()
+  if(!genetic_matrix_builds)
+    return
+
+  for(var/datum/genetic_matrix_build/build as anything in genetic_matrix_builds)
+    if(build.assigned_profile && !(build.assigned_profile in stored_profiles))
+      build.assigned_profile = null
+
+    build.ensure_slot_capacity()
+    for(var/i in 1 to build.ability_paths.len)
+      var/path = build.ability_paths[i]
+      if(!path)
+        continue
+      if(!has_genetic_matrix_ability(path))
+        build.ability_paths[i] = null
+
+/// Generate data for the matrix builds to send to the UI.
+/datum/antagonist/changeling/proc/get_genetic_matrix_builds_data()
+  var/list/output = list()
+  if(!genetic_matrix_builds)
+    return output
+
+  for(var/datum/genetic_matrix_build/build as anything in genetic_matrix_builds)
+    output += list(build.to_data())
+
+  return output
+
+/// Produce a sortable profile dataset for quick access on the matrix tab.
+/datum/antagonist/changeling/proc/get_genetic_matrix_profile_catalog()
+  var/list/catalog = list()
+  if(!stored_profiles)
+    return catalog
+
+  for(var/datum/changeling_profile/profile as anything in stored_profiles)
+    catalog += list(get_genetic_matrix_profile_data(profile))
+
+  sortTim(catalog, GLOBAL_PROC_REF(cmp_assoc_list_name))
+  return catalog
+
+/// Provide profile data for the storage tab.
+/datum/antagonist/changeling/proc/get_genetic_matrix_profile_storage()
+  return get_genetic_matrix_profile_catalog()
+
+/// Aggregate ability information available to the changeling.
+/datum/antagonist/changeling/proc/get_genetic_matrix_ability_catalog()
+  var/list/catalog = list()
+  var/list/seen_paths = list()
+
+  for(var/datum/action/changeling/innate as anything in innate_powers)
+    var/path = innate.type
+    if(!ispath(path))
+      continue
+    if(seen_paths[path])
+      continue
+
+    var/list/entry = get_genetic_matrix_ability_data(path)
+    entry["source"] = "innate"
+    catalog += list(entry)
+    seen_paths[path] = TRUE
+
+  for(var/path in purchased_powers)
+    if(seen_paths[path])
+      continue
+
+    var/list/entry = get_genetic_matrix_ability_data(path)
+    entry["source"] = "purchased"
+    catalog += list(entry)
+    seen_paths[path] = TRUE
+
+  sortTim(catalog, GLOBAL_PROC_REF(cmp_assoc_list_name))
+  return catalog
+
+/// Provide detailed ability data for the storage tab.
+/datum/antagonist/changeling/proc/get_genetic_matrix_ability_storage()
+  return get_genetic_matrix_ability_catalog()
+
+/// Return a dataset summarizing the owner's skills.
+/datum/antagonist/changeling/proc/get_genetic_matrix_skills_data()
+  var/list/data = list()
+  if(!owner)
+    return data
+
+  var/datum/mind/mind = owner
+  if(!mind.known_skills)
+    return data
+
+  for(var/skill_type in mind.known_skills)
+    var/datum/skill/skill_datum = skill_type
+    var/level = mind.get_skill_level(skill_type)
+    var/list/entry = list(
+      "id" = "[skill_type]",
+      "name" = initial(skill_datum.name),
+      "level" = level,
+      "levelName" = mind.get_skill_level_name(skill_type),
+      "exp" = mind.get_skill_exp(skill_type),
+      "desc" = initial(skill_datum.desc),
+    )
+    data += list(entry)
+
+  sortTim(data, GLOBAL_PROC_REF(cmp_assoc_list_name))
+  return data
+
+/// Add a new matrix build for this changeling.
+/datum/antagonist/changeling/proc/add_genetic_matrix_build(name)
+  ensure_genetic_matrix_setup()
+  var/datum/genetic_matrix_build/build = new(src)
+  build.name = name
+  build.ensure_slot_capacity()
+  genetic_matrix_builds += build
+  return build
+
+/// Remove and clean up an existing matrix build.
+/datum/antagonist/changeling/proc/remove_genetic_matrix_build(datum/genetic_matrix_build/build)
+  if(!build)
+    return
+
+  if(build in genetic_matrix_builds)
+    genetic_matrix_builds -= build
+  qdel(build)
+
+/// Clear all assignments from a specific build without deleting it.
+/datum/antagonist/changeling/proc/clear_genetic_matrix_build(datum/genetic_matrix_build/build)
+  if(!build)
+    return
+
+  build.assigned_profile = null
+  build.ensure_slot_capacity()
+  for(var/i in 1 to build.ability_paths.len)
+    build.ability_paths[i] = null
+
+/// Assign a DNA profile to a build.
+/datum/antagonist/changeling/proc/assign_genetic_matrix_profile(datum/genetic_matrix_build/build, datum/changeling_profile/profile)
+  if(!build)
+    return
+
+  if(profile && !(profile in stored_profiles))
+    return
+
+  build.assigned_profile = profile
+
+/// Assign an ability to a slot within a build. Passing null clears the slot.
+/datum/antagonist/changeling/proc/assign_genetic_matrix_ability(datum/genetic_matrix_build/build, datum/action/changeling/ability_path, slot)
+  if(!build)
+    return
+
+  build.ensure_slot_capacity()
+  if(slot < 1 || slot > GENETIC_MATRIX_MAX_ABILITY_SLOTS)
+    return
+
+  if(isnull(ability_path))
+    build.ability_paths[slot] = null
+    return
+
+  if(!has_genetic_matrix_ability(ability_path))
+    return
+
+  build.ability_paths[slot] = ability_path
+
+/// Determine whether the changeling currently possesses a given ability type.
+/datum/antagonist/changeling/proc/has_genetic_matrix_ability(datum/action/changeling/ability_path)
+  if(isnull(ability_path))
+    return FALSE
+
+  if(purchased_powers && purchased_powers[ability_path])
+    return TRUE
+
+  for(var/datum/action/changeling/innate as anything in innate_powers)
+    if(innate.type == ability_path)
+      return TRUE
+
+  return FALSE
+
+/// Locate a matrix build using its reference string.
+/datum/antagonist/changeling/proc/find_genetic_matrix_build(identifier)
+  if(isnull(identifier))
+    return null
+
+  for(var/datum/genetic_matrix_build/build as anything in genetic_matrix_builds)
+    if(REF(build) == identifier)
+      return build
+
+  return null
+
+/// Locate a stored profile using its reference string.
+/datum/antagonist/changeling/proc/find_genetic_matrix_profile(identifier)
+  if(isnull(identifier))
+    return null
+
+  for(var/datum/changeling_profile/profile as anything in stored_profiles)
+    if(REF(profile) == identifier)
+      return profile
+
+  return null
+
+/// Convert a stored profile to UI-friendly data.
+/datum/antagonist/changeling/proc/get_genetic_matrix_profile_data(datum/changeling_profile/profile)
+  var/list/quirk_names = list()
+  for(var/datum/quirk/quirk as anything in profile.quirks)
+    quirk_names += initial(quirk.name)
+
+  var/list/skillchip_names = list()
+  for(var/list/chip_metadata in profile.skillchips)
+    var/chip_type = chip_metadata["type"]
+    if(ispath(chip_type))
+      skillchip_names += initial(chip_type.name)
+    else if(chip_type)
+      skillchip_names += "[chip_type]"
+
+  return list(
+    "id" = REF(profile),
+    "name" = profile.name,
+    "protected" = profile.protected,
+    "age" = profile.age,
+    "physique" = profile.physique,
+    "voice" = profile.voice,
+    "quirks" = quirk_names,
+    "quirk_count" = quirk_names.len,
+    "skillchips" = skillchip_names,
+    "skillchip_count" = skillchip_names.len,
+    "scar_count" = LAZYLEN(profile.stored_scars),
+    "id_icon" = profile.id_icon,
+  )
+
+/// Convert an ability type path to UI-friendly data.
+/datum/antagonist/changeling/proc/get_genetic_matrix_ability_data(datum/action/changeling/ability_path)
+  var/list/data = list(
+    "id" = "[ability_path]",
+    "name" = initial(ability_path.name),
+    "desc" = initial(ability_path.desc),
+    "helptext" = initial(ability_path.helptext),
+    "chemical_cost" = initial(ability_path.chemical_cost),
+    "dna_cost" = initial(ability_path.dna_cost),
+    "req_dna" = initial(ability_path.req_dna),
+    "req_absorbs" = initial(ability_path.req_absorbs),
+    "button_icon_state" = initial(ability_path.button_icon_state),
+  )
+  return data
+
+/// Handle updates when a new DNA profile is added.
+/datum/antagonist/changeling/proc/on_genetic_matrix_profile_added(datum/changeling_profile/profile)
+  ensure_genetic_matrix_setup()
+  for(var/datum/genetic_matrix_build/build as anything in genetic_matrix_builds)
+    if(!build.assigned_profile)
+      build.assigned_profile = profile
+      break
+
+/// Handle updates when a DNA profile is removed.
+/datum/antagonist/changeling/proc/on_genetic_matrix_profile_removed(datum/changeling_profile/profile)
+  if(!genetic_matrix_builds)
+    return
+
+  for(var/datum/genetic_matrix_build/build as anything in genetic_matrix_builds)
+    if(build.assigned_profile == profile)
+      build.assigned_profile = null
+
+#undef GENETIC_MATRIX_MAX_ABILITY_SLOTS
+#undef GENETIC_MATRIX_MAX_BUILDS
+

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3358,6 +3358,7 @@
 #include "code\modules\antagonists\brainwashing\brainwashing.dm"
 #include "code\modules\antagonists\brother\brother.dm"
 #include "code\modules\antagonists\changeling\cellular_emporium.dm"
+#include "code\modules\antagonists\changeling\genetic_matrix.dm"
 #include "code\modules\antagonists\changeling\changeling.dm"
 #include "code\modules\antagonists\changeling\changeling_power.dm"
 #include "code\modules\antagonists\changeling\fallen_changeling.dm"

--- a/tgui/packages/tgui/interfaces/GeneticMatrix.tsx
+++ b/tgui/packages/tgui/interfaces/GeneticMatrix.tsx
@@ -1,0 +1,1091 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import type { DragEvent } from 'react';
+import {
+  Box,
+  Button,
+  Divider,
+  Icon,
+  NoticeBox,
+  Section,
+  Stack,
+  Tabs,
+  Table,
+} from 'tgui-core/components';
+import type { BooleanLike } from 'tgui-core/react';
+
+import { useBackend, useLocalState } from '../backend';
+import { Window } from '../layouts';
+
+const DRAG_DATA_KEY = 'application/x-genetic-matrix';
+
+const asBoolean = (value: BooleanLike | undefined): boolean => {
+  if (typeof value === 'boolean') {
+    return value;
+  }
+  if (typeof value === 'number') {
+    return value !== 0;
+  }
+  if (typeof value === 'string') {
+    const lowered = value.toLowerCase();
+    return lowered !== '0' && lowered !== 'false' && lowered !== '';
+  }
+  return Boolean(value);
+};
+
+const formatValue = (value: unknown, fallback = 'Unknown') => {
+  if (value === undefined || value === null || value === '') {
+    return fallback;
+  }
+  return String(value);
+};
+
+type ProfileEntry = {
+  id: string;
+  name: string;
+  protected: BooleanLike;
+  age: number | string | null;
+  physique: string | null;
+  voice: string | null;
+  quirks: string[];
+  quirk_count: number;
+  skillchips: string[];
+  skillchip_count: number;
+  scar_count: number;
+  id_icon: string | null;
+};
+
+type AbilityEntry = {
+  id: string;
+  name: string;
+  desc: string;
+  helptext: string;
+  chemical_cost: number;
+  dna_cost: number;
+  req_dna: number;
+  req_absorbs: number;
+  button_icon_state: string | null;
+  source?: string;
+  slot?: number;
+};
+
+type BuildEntry = {
+  id: string;
+  name: string;
+  profile: ProfileEntry | null;
+  abilities: (AbilityEntry | null)[];
+};
+
+type SkillEntry = {
+  id: string;
+  name: string;
+  level: number;
+  levelName: string;
+  exp: number;
+  desc: string;
+};
+
+type GeneticMatrixData = {
+  maxAbilitySlots: number;
+  maxBuilds: number;
+  builds: BuildEntry[];
+  resultCatalog: ProfileEntry[];
+  abilityCatalog: AbilityEntry[];
+  cells: ProfileEntry[];
+  abilities: AbilityEntry[];
+  skills: SkillEntry[];
+  canAddBuild: BooleanLike;
+};
+
+type DragPayload =
+  | { type: 'profile'; id: string }
+  | { type: 'profile-slot'; id: string; buildId: string }
+  | { type: 'ability'; id: string }
+  | { type: 'ability-slot'; id: string; buildId: string; slot: number };
+
+export const GeneticMatrix = () => {
+  const { act, data } = useBackend<GeneticMatrixData>();
+  const {
+    builds = [],
+    resultCatalog = [],
+    abilityCatalog = [],
+    cells = [],
+    abilities = [],
+    skills = [],
+    canAddBuild,
+    maxAbilitySlots = 0,
+    maxBuilds = 0,
+  } = data;
+
+  const [activeTab, setActiveTab] = useLocalState<'matrix' | 'cells' | 'abilities' | 'skills'>(
+    'genetic-matrix/tab',
+    'matrix',
+  );
+  const [selectedBuildId, setSelectedBuildId] = useLocalState<string | undefined>(
+    'genetic-matrix/selected-build',
+    undefined,
+  );
+
+  useEffect(() => {
+    if (!builds.length) {
+      if (selectedBuildId !== undefined) {
+        setSelectedBuildId(undefined);
+      }
+      return;
+    }
+
+    const stillExists = builds.some((build) => build.id === selectedBuildId);
+    if (!selectedBuildId || !stillExists) {
+      setSelectedBuildId(builds[0].id);
+    }
+  }, [builds, selectedBuildId, setSelectedBuildId]);
+
+  const selectedBuild = useMemo(
+    () => builds.find((build) => build.id === selectedBuildId),
+    [builds, selectedBuildId],
+  );
+
+  return (
+    <Window width={1024} height={720}>
+      <Window.Content>
+        <Stack vertical fill>
+          <Stack.Item>
+            <Tabs>
+              <Tabs.Tab
+                selected={activeTab === 'matrix'}
+                onClick={() => setActiveTab('matrix')}
+              >
+                Matrix
+              </Tabs.Tab>
+              <Tabs.Tab
+                selected={activeTab === 'cells'}
+                onClick={() => setActiveTab('cells')}
+              >
+                Cells Storage
+              </Tabs.Tab>
+              <Tabs.Tab
+                selected={activeTab === 'abilities'}
+                onClick={() => setActiveTab('abilities')}
+              >
+                Abilities Storage
+              </Tabs.Tab>
+              <Tabs.Tab
+                selected={activeTab === 'skills'}
+                onClick={() => setActiveTab('skills')}
+              >
+                Standard Skills
+              </Tabs.Tab>
+            </Tabs>
+          </Stack.Item>
+          <Stack.Item grow>
+            {activeTab === 'matrix' && (
+              <MatrixTab
+                act={act}
+                builds={builds}
+                selectedBuild={selectedBuild}
+                selectedBuildId={selectedBuildId}
+                onSelectBuild={setSelectedBuildId}
+                resultCatalog={resultCatalog}
+                abilityCatalog={abilityCatalog}
+                maxAbilitySlots={maxAbilitySlots}
+                canAddBuild={asBoolean(canAddBuild)}
+                maxBuilds={maxBuilds}
+              />
+            )}
+            {activeTab === 'cells' && <CellsTab profiles={cells} />}
+            {activeTab === 'abilities' && (
+              <AbilitiesStorageTab abilities={abilities} />
+            )}
+            {activeTab === 'skills' && <SkillsTab skills={skills} />}
+          </Stack.Item>
+        </Stack>
+      </Window.Content>
+    </Window>
+  );
+};
+
+type MatrixTabProps = {
+  act: (action: string, payload?: Record<string, unknown>) => void;
+  builds: BuildEntry[];
+  selectedBuild: BuildEntry | undefined;
+  selectedBuildId: string | undefined;
+  onSelectBuild: (id: string) => void;
+  resultCatalog: ProfileEntry[];
+  abilityCatalog: AbilityEntry[];
+  maxAbilitySlots: number;
+  canAddBuild: boolean;
+  maxBuilds: number;
+};
+
+const MatrixTab = ({
+  act,
+  builds,
+  selectedBuild,
+  selectedBuildId,
+  onSelectBuild,
+  resultCatalog,
+  abilityCatalog,
+  maxAbilitySlots,
+  canAddBuild,
+  maxBuilds,
+}: MatrixTabProps) => {
+  const [dragPayload, setDragPayload] = useState<DragPayload | null>(null);
+
+  const beginDrag = useCallback(
+    (event: DragEvent, payload: DragPayload) => {
+      setDragPayload(payload);
+      try {
+        event.dataTransfer.setData(DRAG_DATA_KEY, JSON.stringify(payload));
+      } catch {
+        // ignore errors writing drag payload
+      }
+      event.dataTransfer.setData('text/plain', payload.id);
+      event.dataTransfer.effectAllowed = 'move';
+    },
+    [],
+  );
+
+  const endDrag = useCallback(() => {
+    setDragPayload(null);
+  }, []);
+
+  const parsePayload = useCallback(
+    (event: DragEvent): DragPayload | null => {
+      const raw = event.dataTransfer.getData(DRAG_DATA_KEY);
+      if (raw) {
+        try {
+          return JSON.parse(raw) as DragPayload;
+        } catch {
+          // ignore malformed payloads
+        }
+      }
+      return dragPayload;
+    },
+    [dragPayload],
+  );
+
+  const handleAssignProfile = useCallback(
+    (buildId: string, profileId: string | null) => {
+      if (!profileId) {
+        act('clear_build_profile', { build: buildId });
+        return;
+      }
+      act('set_build_profile', { build: buildId, profile: profileId });
+    },
+    [act],
+  );
+
+  const handleAssignAbility = useCallback(
+    (buildId: string, slot: number, abilityId: string | null) => {
+      if (!abilityId) {
+        act('clear_build_ability', { build: buildId, slot });
+        return;
+      }
+      act('set_build_ability', { build: buildId, slot, ability: abilityId });
+    },
+    [act],
+  );
+
+  const handleClearBuild = useCallback(
+    (buildId: string) => {
+      act('clear_build', { build: buildId });
+    },
+    [act],
+  );
+
+  const handleRenameBuild = useCallback(
+    (buildId: string) => {
+      act('rename_build', { build: buildId });
+    },
+    [act],
+  );
+
+  const handleDeleteBuild = useCallback(
+    (buildId: string) => {
+      act('delete_build', { build: buildId });
+    },
+    [act],
+  );
+
+  const handleCreateBuild = useCallback(() => {
+    act('create_build');
+  }, [act]);
+
+  const assignedAbilityIds = useMemo(() => {
+    if (!selectedBuild) {
+      return new Set<string>();
+    }
+    return new Set(
+      selectedBuild.abilities
+        .filter((entry): entry is AbilityEntry => Boolean(entry))
+        .map((entry) => entry.id),
+    );
+  }, [selectedBuild]);
+
+  const handleProfileDrop = useCallback(
+    (payload: DragPayload, targetBuild: BuildEntry) => {
+      if (payload.type === 'profile') {
+        handleAssignProfile(targetBuild.id, payload.id);
+        return;
+      }
+      if (payload.type === 'profile-slot') {
+        if (payload.buildId === targetBuild.id) {
+          return;
+        }
+        handleAssignProfile(targetBuild.id, payload.id);
+        act('clear_build_profile', { build: payload.buildId });
+      }
+    },
+    [act, handleAssignProfile],
+  );
+
+  const handleAbilityDrop = useCallback(
+    (payload: DragPayload, targetBuild: BuildEntry, slot: number) => {
+      if (payload.type === 'ability') {
+        handleAssignAbility(targetBuild.id, slot, payload.id);
+        return;
+      }
+      if (payload.type === 'ability-slot') {
+        if (payload.buildId === targetBuild.id && payload.slot === slot) {
+          return;
+        }
+        handleAssignAbility(targetBuild.id, slot, payload.id);
+        act('clear_build_ability', { build: payload.buildId, slot: payload.slot });
+      }
+    },
+    [act, handleAssignAbility],
+  );
+
+  const handleProfileDoubleClick = useCallback(
+    (profile: ProfileEntry) => {
+      if (!selectedBuild) {
+        return;
+      }
+      handleAssignProfile(selectedBuild.id, profile.id);
+    },
+    [handleAssignProfile, selectedBuild],
+  );
+
+  const handleAbilityDoubleClick = useCallback(
+    (ability: AbilityEntry) => {
+      if (!selectedBuild || maxAbilitySlots <= 0) {
+        return;
+      }
+      const openIndex =
+        selectedBuild.abilities.findIndex((entry) => !entry) + 1;
+      const slot =
+        openIndex > 0
+          ? openIndex
+          : selectedBuild.abilities.length > 0
+            ? 1
+            : 0;
+      if (slot > 0) {
+        handleAssignAbility(selectedBuild.id, slot, ability.id);
+      }
+    },
+    [handleAssignAbility, maxAbilitySlots, selectedBuild],
+  );
+
+  return (
+    <Stack fill gap={1}>
+      <Stack.Item width="280px">
+        <BuildList
+          builds={builds}
+          selectedBuildId={selectedBuildId}
+          onSelect={onSelectBuild}
+          onCreate={handleCreateBuild}
+          onRename={handleRenameBuild}
+          onClear={handleClearBuild}
+          onDelete={handleDeleteBuild}
+          canAddBuild={canAddBuild}
+          maxBuilds={maxBuilds}
+        />
+      </Stack.Item>
+      <Stack.Item grow>
+        <Stack vertical fill gap={1}>
+          <Stack.Item>
+            <BuildEditor
+              build={selectedBuild}
+              maxAbilitySlots={maxAbilitySlots}
+              dragPayload={dragPayload}
+              beginDrag={beginDrag}
+              endDrag={endDrag}
+              parsePayload={parsePayload}
+              onClearProfile={(buildId) => handleAssignProfile(buildId, null)}
+              onClearAbility={(buildId, slot) => handleAssignAbility(buildId, slot, null)}
+              onClearBuild={handleClearBuild}
+              onProfileDropped={handleProfileDrop}
+              onAbilityDropped={handleAbilityDrop}
+            />
+          </Stack.Item>
+          <Stack.Item grow>
+            <Stack fill gap={1}>
+              <Stack.Item grow>
+                <ProfileCatalog
+                  title="Result Catalog"
+                  profiles={resultCatalog}
+                  allowDrag
+                  onDragStart={(profile, event) =>
+                    beginDrag(event, { type: 'profile', id: profile.id })
+                  }
+                  onDragEnd={endDrag}
+                  onDoubleClick={handleProfileDoubleClick}
+                  highlightId={selectedBuild?.profile?.id}
+                  emptyMessage="We have not stored any DNA samples yet."
+                />
+              </Stack.Item>
+              <Stack.Item grow>
+                <AbilityList
+                  title="Ability Catalog"
+                  abilities={abilityCatalog}
+                  allowDrag
+                  onDragStart={(ability, event) =>
+                    beginDrag(event, { type: 'ability', id: ability.id })
+                  }
+                  onDragEnd={endDrag}
+                  onDoubleClick={handleAbilityDoubleClick}
+                  assignedAbilityIds={assignedAbilityIds}
+                  emptyMessage="We do not possess any abilities to assign."
+                />
+              </Stack.Item>
+            </Stack>
+          </Stack.Item>
+        </Stack>
+      </Stack.Item>
+    </Stack>
+  );
+};
+
+type BuildListProps = {
+  builds: BuildEntry[];
+  selectedBuildId: string | undefined;
+  onSelect: (id: string) => void;
+  onCreate: () => void;
+  onRename: (id: string) => void;
+  onClear: (id: string) => void;
+  onDelete: (id: string) => void;
+  canAddBuild: boolean;
+  maxBuilds: number;
+};
+
+const BuildList = ({
+  builds,
+  selectedBuildId,
+  onSelect,
+  onCreate,
+  onRename,
+  onClear,
+  onDelete,
+  canAddBuild,
+  maxBuilds,
+}: BuildListProps) => (
+  <Section
+    title="Builds"
+    fill
+    scrollable
+    buttons={
+      <Stack align="center" gap={1}>
+        <Stack.Item textColor="label">
+          {builds.length}/{maxBuilds}
+        </Stack.Item>
+        <Stack.Item>
+          <Button
+            icon="plus"
+            tooltip="Create a new build"
+            disabled={!canAddBuild}
+            onClick={onCreate}
+          >
+            New
+          </Button>
+        </Stack.Item>
+      </Stack>
+    }
+  >
+    {builds.length === 0 ? (
+      <NoticeBox>
+        No builds configured yet. Create a build to start composing the matrix.
+      </NoticeBox>
+    ) : (
+      <Stack vertical gap={1}>
+        {builds.map((build) => {
+          const isSelected = selectedBuildId === build.id;
+          const hasAssignments =
+            Boolean(build.profile) || build.abilities.some((ability) => ability);
+          return (
+            <Box
+              key={build.id}
+              className="candystripe"
+              p={1}
+              style={{
+                border: `1px solid ${
+                  isSelected ? '#7fc' : 'rgba(255, 255, 255, 0.1)'
+                }`,
+                borderRadius: '6px',
+                backgroundColor: isSelected
+                  ? 'rgba(64, 160, 255, 0.08)'
+                  : 'rgba(255,255,255,0.03)',
+              }}
+            >
+              <Stack vertical gap={0.5}>
+                <Stack.Item>
+                  <Button
+                    fluid
+                    selected={isSelected}
+                    onClick={() => onSelect(build.id)}
+                  >
+                    {build.name}
+                  </Button>
+                </Stack.Item>
+                <Stack.Item>
+                  <Stack gap={1} wrap>
+                    <Stack.Item>
+                      <Button
+                        icon="pen"
+                        tooltip="Rename this build"
+                        onClick={() => onRename(build.id)}
+                      />
+                    </Stack.Item>
+                    <Stack.Item>
+                      <Button
+                        icon="eraser"
+                        tooltip="Clear all assignments"
+                        disabled={!hasAssignments}
+                        onClick={() => onClear(build.id)}
+                      />
+                    </Stack.Item>
+                    <Stack.Item>
+                      <Button
+                        icon="trash"
+                        color="bad"
+                        tooltip="Delete this build"
+                        onClick={() => onDelete(build.id)}
+                      />
+                    </Stack.Item>
+                  </Stack>
+                </Stack.Item>
+                {build.profile && (
+                  <Stack.Item color="label">
+                    Profile: {build.profile.name}
+                  </Stack.Item>
+                )}
+              </Stack>
+            </Box>
+          );
+        })}
+      </Stack>
+    )}
+  </Section>
+);
+
+type BuildEditorProps = {
+  build: BuildEntry | undefined;
+  maxAbilitySlots: number;
+  dragPayload: DragPayload | null;
+  beginDrag: (event: DragEvent, payload: DragPayload) => void;
+  endDrag: () => void;
+  parsePayload: (event: DragEvent) => DragPayload | null;
+  onClearProfile: (buildId: string) => void;
+  onClearAbility: (buildId: string, slot: number) => void;
+  onClearBuild: (buildId: string) => void;
+  onProfileDropped: (payload: DragPayload, build: BuildEntry) => void;
+  onAbilityDropped: (payload: DragPayload, build: BuildEntry, slot: number) => void;
+};
+
+const BuildEditor = ({
+  build,
+  maxAbilitySlots,
+  dragPayload,
+  beginDrag,
+  endDrag,
+  parsePayload,
+  onClearProfile,
+  onClearAbility,
+  onClearBuild,
+  onProfileDropped,
+  onAbilityDropped,
+}: BuildEditorProps) => {
+  if (!build) {
+    return (
+      <Section title="Build Editor">
+        <NoticeBox>
+          Select or create a build to begin editing your genetic matrix.
+        </NoticeBox>
+      </Section>
+    );
+  }
+
+  const profile = build.profile;
+  const profileActive =
+    dragPayload?.type === 'profile' || dragPayload?.type === 'profile-slot';
+
+  return (
+    <Section
+      title={`Build Editor — ${build.name}`}
+      buttons={
+        <Button icon="eraser" tooltip="Clear all assignments" onClick={() => onClearBuild(build.id)}>
+          Clear Build
+        </Button>
+      }
+    >
+      <Stack vertical gap={1}>
+        <Stack.Item>
+          <Stack align="center" gap={1}>
+            <Stack.Item grow>
+              <Box
+                p={1}
+                draggable={Boolean(profile)}
+                onDragStart={(event) => {
+                  if (!profile) {
+                    return;
+                  }
+                  beginDrag(event, {
+                    type: 'profile-slot',
+                    id: profile.id,
+                    buildId: build.id,
+                  });
+                }}
+                onDragEnd={endDrag}
+                onDragOver={(event) => {
+                  const payload = parsePayload(event);
+                  if (!payload) {
+                    return;
+                  }
+                  if (payload.type === 'profile' || payload.type === 'profile-slot') {
+                    event.preventDefault();
+                    event.dataTransfer.dropEffect = 'move';
+                  }
+                }}
+                onDrop={(event) => {
+                  const payload = parsePayload(event);
+                  if (!payload) {
+                    return;
+                  }
+                  if (payload.type === 'profile' || payload.type === 'profile-slot') {
+                    event.preventDefault();
+                    onProfileDropped(payload, build);
+                    endDrag();
+                  }
+                }}
+                style={{
+                  border: `1px dashed ${
+                    profileActive ? '#7fc' : 'rgba(255, 255, 255, 0.2)'
+                  }`,
+                  borderRadius: '6px',
+                  minHeight: '96px',
+                  backgroundColor: profileActive
+                    ? 'rgba(64, 160, 255, 0.1)'
+                    : 'rgba(255,255,255,0.03)',
+                }}
+              >
+                {profile ? (
+                  <ProfileSummary profile={profile} />
+                ) : (
+                  <Box color="label">
+                    Drag a DNA profile from the catalog to assign it to this build.
+                  </Box>
+                )}
+              </Box>
+            </Stack.Item>
+            <Stack.Item>
+              <Button
+                icon="times"
+                disabled={!profile}
+                tooltip="Remove the assigned profile"
+                onClick={() => onClearProfile(build.id)}
+                onDragOver={(event) => {
+                  const payload = parsePayload(event);
+                  if (
+                    payload &&
+                    payload.type === 'profile-slot' &&
+                    payload.buildId === build.id
+                  ) {
+                    event.preventDefault();
+                    event.dataTransfer.dropEffect = 'move';
+                  }
+                }}
+                onDrop={(event) => {
+                  const payload = parsePayload(event);
+                  if (
+                    payload &&
+                    payload.type === 'profile-slot' &&
+                    payload.buildId === build.id
+                  ) {
+                    event.preventDefault();
+                    onClearProfile(build.id);
+                    endDrag();
+                  }
+                }}
+              />
+            </Stack.Item>
+          </Stack>
+        </Stack.Item>
+        <Divider />
+        <Stack.Item>
+          <Stack vertical gap={1}>
+            {Array.from({ length: maxAbilitySlots }, (_, index) => {
+              const slot = index + 1;
+              const ability = build.abilities[index] ?? null;
+              const highlight =
+                dragPayload &&
+                (dragPayload.type === 'ability' ||
+                  (dragPayload.type === 'ability-slot' &&
+                    (dragPayload.buildId !== build.id ||
+                      dragPayload.slot !== slot)));
+              return (
+                <Stack align="center" gap={1} key={slot}>
+                  <Stack.Item width="64px">
+                    <Box textAlign="center" bold>
+                      Slot {slot}
+                    </Box>
+                  </Stack.Item>
+                  <Stack.Item grow>
+                    <Box
+                      p={1}
+                      draggable={Boolean(ability)}
+                      onDragStart={(event) => {
+                        if (!ability) {
+                          return;
+                        }
+                        beginDrag(event, {
+                          type: 'ability-slot',
+                          id: ability.id,
+                          buildId: build.id,
+                          slot,
+                        });
+                      }}
+                      onDragEnd={endDrag}
+                      onDragOver={(event) => {
+                        const payload = parsePayload(event);
+                        if (!payload) {
+                          return;
+                        }
+                        if (
+                          payload.type === 'ability' ||
+                          payload.type === 'ability-slot'
+                        ) {
+                          event.preventDefault();
+                          event.dataTransfer.dropEffect = 'move';
+                        }
+                      }}
+                      onDrop={(event) => {
+                        const payload = parsePayload(event);
+                        if (!payload) {
+                          return;
+                        }
+                        if (
+                          payload.type === 'ability' ||
+                          payload.type === 'ability-slot'
+                        ) {
+                          event.preventDefault();
+                          onAbilityDropped(payload, build, slot);
+                          endDrag();
+                        }
+                      }}
+                      style={{
+                        border: `1px dashed ${
+                          highlight ? '#7fc' : 'rgba(255, 255, 255, 0.2)'
+                        }`,
+                        borderRadius: '6px',
+                        minHeight: '72px',
+                        backgroundColor: highlight
+                          ? 'rgba(64, 160, 255, 0.1)'
+                          : 'rgba(255,255,255,0.03)',
+                      }}
+                    >
+                      {ability ? (
+                        <AbilitySummary ability={ability} showSource={false} />
+                      ) : (
+                        <Box color="label">Drop an ability here.</Box>
+                      )}
+                    </Box>
+                  </Stack.Item>
+                  <Stack.Item>
+                    <Button
+                      icon="times"
+                      disabled={!ability}
+                      tooltip="Clear this slot"
+                      onClick={() => onClearAbility(build.id, slot)}
+                    />
+                  </Stack.Item>
+                </Stack>
+              );
+            })}
+            {maxAbilitySlots === 0 && (
+              <NoticeBox>
+                This build has no ability slots available.
+              </NoticeBox>
+            )}
+          </Stack>
+        </Stack.Item>
+      </Stack>
+    </Section>
+  );
+};
+
+type ProfileCatalogProps = {
+  title: string;
+  profiles: ProfileEntry[];
+  allowDrag?: boolean;
+  onDragStart?: (profile: ProfileEntry, event: DragEvent) => void;
+  onDragEnd?: () => void;
+  onDoubleClick?: (profile: ProfileEntry) => void;
+  highlightId?: string;
+  emptyMessage?: string;
+};
+
+const ProfileCatalog = ({
+  title,
+  profiles,
+  allowDrag = false,
+  onDragStart,
+  onDragEnd,
+  onDoubleClick,
+  highlightId,
+  emptyMessage,
+}: ProfileCatalogProps) => (
+  <Section title={title} fill scrollable>
+    {profiles.length === 0 ? (
+      <NoticeBox>{emptyMessage ?? 'No DNA profiles available.'}</NoticeBox>
+    ) : (
+      <Stack vertical gap={1}>
+        {profiles.map((profile) => {
+          const isSelected = highlightId === profile.id;
+          return (
+            <Box
+              key={profile.id}
+              className="candystripe"
+              p={1}
+              draggable={allowDrag}
+              onDragStart={
+                allowDrag
+                  ? (event) => onDragStart?.(profile, event)
+                  : undefined
+              }
+              onDragEnd={allowDrag ? onDragEnd : undefined}
+              onDoubleClick={
+                onDoubleClick ? () => onDoubleClick(profile) : undefined
+              }
+              style={{
+                border: `1px solid ${
+                  isSelected ? '#7fc' : 'rgba(255, 255, 255, 0.1)'
+                }`,
+                borderRadius: '6px',
+                backgroundColor: isSelected
+                  ? 'rgba(64, 160, 255, 0.08)'
+                  : 'rgba(255,255,255,0.03)',
+              }}
+            >
+              <ProfileSummary profile={profile} />
+            </Box>
+          );
+        })}
+      </Stack>
+    )}
+  </Section>
+);
+
+type AbilityListProps = {
+  title: string;
+  abilities: AbilityEntry[];
+  allowDrag?: boolean;
+  onDragStart?: (ability: AbilityEntry, event: DragEvent) => void;
+  onDragEnd?: () => void;
+  onDoubleClick?: (ability: AbilityEntry) => void;
+  assignedAbilityIds?: Set<string>;
+  emptyMessage?: string;
+};
+
+const AbilityList = ({
+  title,
+  abilities,
+  allowDrag = false,
+  onDragStart,
+  onDragEnd,
+  onDoubleClick,
+  assignedAbilityIds,
+  emptyMessage,
+}: AbilityListProps) => (
+  <Section title={title} fill scrollable>
+    {abilities.length === 0 ? (
+      <NoticeBox>{emptyMessage ?? 'No abilities available.'}</NoticeBox>
+    ) : (
+      <Stack vertical gap={1}>
+        {abilities.map((ability) => {
+          const isAssigned = assignedAbilityIds?.has(ability.id);
+          return (
+            <Box
+              key={ability.id}
+              className="candystripe"
+              p={1}
+              draggable={allowDrag}
+              onDragStart={
+                allowDrag
+                  ? (event) => onDragStart?.(ability, event)
+                  : undefined
+              }
+              onDragEnd={allowDrag ? onDragEnd : undefined}
+              onDoubleClick={
+                onDoubleClick ? () => onDoubleClick(ability) : undefined
+              }
+              style={{
+                border: `1px solid ${
+                  isAssigned ? '#7fc' : 'rgba(255, 255, 255, 0.1)'
+                }`,
+                borderRadius: '6px',
+                backgroundColor: isAssigned
+                  ? 'rgba(64, 160, 255, 0.08)'
+                  : 'rgba(255,255,255,0.03)',
+              }}
+            >
+              <AbilitySummary ability={ability} />
+            </Box>
+          );
+        })}
+      </Stack>
+    )}
+  </Section>
+);
+
+const formatSource = (source?: string) => {
+  if (!source) {
+    return '';
+  }
+  const lowered = source.toLowerCase();
+  if (lowered === 'innate') {
+    return 'Innate';
+  }
+  if (lowered === 'purchased') {
+    return 'Purchased';
+  }
+  return source;
+};
+
+type ProfileSummaryProps = {
+  profile: ProfileEntry;
+};
+
+const ProfileSummary = ({ profile }: ProfileSummaryProps) => {
+  const protectedProfile = asBoolean(profile.protected);
+  const quirks = profile.quirks ?? [];
+  const skillchips = profile.skillchips ?? [];
+  return (
+    <Stack vertical gap={0.5}>
+      <Stack.Item>
+        <Stack align="center" gap={0.5}>
+          <Stack.Item>
+            <Box bold>{profile.name}</Box>
+          </Stack.Item>
+          {protectedProfile && (
+            <Stack.Item>
+              <Icon name="shield-alt" color="good" />
+            </Stack.Item>
+          )}
+        </Stack>
+      </Stack.Item>
+      <Stack.Item color="label">
+        Age: {formatValue(profile.age)} | Physique: {formatValue(profile.physique)} |
+        {' '}
+        Voice: {formatValue(profile.voice)}
+      </Stack.Item>
+      {quirks.length > 0 && (
+        <Stack.Item color="label">
+          Quirks: {quirks.join(', ')}
+        </Stack.Item>
+      )}
+      {skillchips.length > 0 && (
+        <Stack.Item color="label">
+          Skillchips: {skillchips.join(', ')}
+        </Stack.Item>
+      )}
+      <Stack.Item color="label">Scars: {profile.scar_count}</Stack.Item>
+    </Stack>
+  );
+};
+
+type AbilitySummaryProps = {
+  ability: AbilityEntry;
+  showSource?: boolean;
+};
+
+const AbilitySummary = ({ ability, showSource = true }: AbilitySummaryProps) => {
+  const sourceLabel = showSource ? formatSource(ability.source) : '';
+  const sourceColor = ability.source?.toLowerCase() === 'innate' ? 'good' : 'average';
+  return (
+    <Stack vertical gap={0.5}>
+      <Stack.Item>
+        <Stack justify="space-between" align="center" gap={0.5}>
+          <Stack.Item>
+            <Box bold>{ability.name}</Box>
+          </Stack.Item>
+          {sourceLabel && (
+            <Stack.Item>
+              <Box color={sourceColor}>{sourceLabel}</Box>
+            </Stack.Item>
+          )}
+        </Stack>
+      </Stack.Item>
+      <Stack.Item color="label">
+        Chems: {ability.chemical_cost} | DNA: {ability.dna_cost} | Required DNA:{' '}
+        {ability.req_dna} | Required Absorbs: {ability.req_absorbs}
+      </Stack.Item>
+      {ability.desc && <Stack.Item>{ability.desc}</Stack.Item>}
+      {ability.helptext && <Stack.Item color="good">{ability.helptext}</Stack.Item>}
+    </Stack>
+  );
+};
+
+type CellsTabProps = {
+  profiles: ProfileEntry[];
+};
+
+const CellsTab = ({ profiles }: CellsTabProps) => (
+  <ProfileCatalog
+    title="Cells Storage"
+    profiles={profiles}
+    allowDrag={false}
+    emptyMessage="We have no stored DNA samples."
+  />
+);
+
+type AbilitiesStorageTabProps = {
+  abilities: AbilityEntry[];
+};
+
+const AbilitiesStorageTab = ({ abilities }: AbilitiesStorageTabProps) => (
+  <AbilityList
+    title="Abilities Storage"
+    abilities={abilities}
+    allowDrag={false}
+    emptyMessage="We have not acquired any abilities."
+  />
+);
+
+type SkillsTabProps = {
+  skills: SkillEntry[];
+};
+
+const SkillsTab = ({ skills }: SkillsTabProps) => (
+  <Section title="Standard Skills" fill scrollable>
+    {skills.length === 0 ? (
+      <NoticeBox>No skills recorded for this changeling.</NoticeBox>
+    ) : (
+      <Table>
+        <Table.Row header>
+          <Table.Cell>Skill</Table.Cell>
+          <Table.Cell>Level</Table.Cell>
+          <Table.Cell>Experience</Table.Cell>
+          <Table.Cell>Description</Table.Cell>
+        </Table.Row>
+        {skills.map((skill) => (
+          <Table.Row key={skill.id} className="candystripe">
+            <Table.Cell>{skill.name}</Table.Cell>
+            <Table.Cell>
+              {skill.levelName} (Level {skill.level})
+            </Table.Cell>
+            <Table.Cell>{skill.exp}</Table.Cell>
+            <Table.Cell>{skill.desc}</Table.Cell>
+          </Table.Row>
+        ))}
+      </Table>
+    )}
+  </Section>
+);


### PR DESCRIPTION
## Summary
- add a genetic matrix action to changelings with lifecycle cleanup and build syncing
- implement the genetic matrix datum supplying build, profile, ability, and skill data for the UI
- introduce the TGUI GeneticMatrix panel with matrix editing, storage, and skill tabs; include new DM file in the DME

## Testing
- `npm run tgui:lint` *(fails: existing lint violations in unrelated legacy assets)*

------
https://chatgpt.com/codex/tasks/task_e_68cd6def94f0832a8eaaaa8c60cb8ab0