### PR TITLE
Fix skillchip name lookup in genetic matrix

### DIFF
--- a/code/modules/antagonists/changeling/genetic_matrix.dm
+++ b/code/modules/antagonists/changeling/genetic_matrix.dm
@@ -454,8 +454,9 @@
   var/list/skillchip_names = list()
   for(var/list/chip_metadata in profile.skillchips)
     var/chip_type = chip_metadata["type"]
-    if(ispath(chip_type))
-      skillchip_names += initial(chip_type.name)
+    if(ispath(chip_type, /obj/item/skillchip))
+      var/obj/item/skillchip/skillchip_type = chip_type
+      skillchip_names += initial(skillchip_type.name)
     else if(chip_type)
       skillchip_names += "[chip_type]"
 


### PR DESCRIPTION
## Summary
- ensure the changeling genetic matrix verifies skillchip metadata entries are skillchip paths before reading their names
- retrieve skillchip names using a typed skillchip reference to avoid compile errors

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cd8bb9b218832a9365b121f2a6582d