### PR TITLE
Prevent changeling matrix setup recursion

### DIFF
--- a/code/modules/antagonists/changeling/genetic_matrix.dm
+++ b/code/modules/antagonists/changeling/genetic_matrix.dm
@@ -244,11 +244,10 @@
 
 /// Ensure that the matrix data structures exist and have at least one build configured.
 /datum/antagonist/changeling/proc/ensure_genetic_matrix_setup()
-  if(!genetic_matrix_builds)
-    genetic_matrix_builds = list()
+  if(genetic_matrix_builds && genetic_matrix_builds.len)
+    return
 
-  if(!genetic_matrix_builds.len)
-    add_genetic_matrix_build("Matrix Build 1")
+  add_genetic_matrix_build("Matrix Build 1")
 
 /// Remove invalid references from matrix builds.
 /datum/antagonist/changeling/proc/prune_genetic_matrix_assignments()
@@ -355,7 +354,8 @@
 
 /// Add a new matrix build for this changeling.
 /datum/antagonist/changeling/proc/add_genetic_matrix_build(name)
-  ensure_genetic_matrix_setup()
+  if(!genetic_matrix_builds)
+    genetic_matrix_builds = list()
   var/datum/genetic_matrix_build/build = new(src)
   build.name = name
   build.ensure_slot_capacity()


### PR DESCRIPTION
## Summary
- create the changeling genetic matrix build list on demand inside `add_genetic_matrix_build`
- keep `ensure_genetic_matrix_setup` focused on seeding the default build without triggering recursion

## Testing
- tools/build/build.sh *(fails: 403 downloading external dependencies)*
- tools/build/build.sh dm --skip-icon-cutter *(fails: DreamMaker executable not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cd93a7e204832ab54f27b561b53dc9