### PR TITLE
Fix changeling genetic matrix action availability checks

### DIFF
--- a/code/modules/antagonists/changeling/genetic_matrix.dm
+++ b/code/modules/antagonists/changeling/genetic_matrix.dm
@@ -235,12 +235,18 @@
     qdel(src)
 
 /datum/action/changeling/genetic_matrix/Trigger(mob/clicker, trigger_flags)
-  . = ..()
-  if(!.)
-    return
+  if(!(trigger_flags & TRIGGER_FORCE_AVAILABLE) && !IsAvailable(feedback = TRUE))
+    return FALSE
+
+  if(SEND_SIGNAL(src, COMSIG_ACTION_TRIGGER, src) & COMPONENT_ACTION_BLOCK_TRIGGER)
+    return FALSE
 
   var/datum/genetic_matrix/matrix = target
+  if(!matrix)
+    return FALSE
+
   matrix.ui_interact(owner)
+  return TRUE
 
 /// Ensure that the matrix data structures exist and have at least one build configured.
 /datum/antagonist/changeling/proc/ensure_genetic_matrix_setup()


### PR DESCRIPTION
## Summary
- update the changeling genetic matrix action to run standard availability checks before opening the UI

## Testing
- Not run (environment does not support BYOND compilation/runtime)


------
https://chatgpt.com/codex/tasks/task_e_68cd98f5662c832a8cd59a12f5597b50