### PR TITLE
Fix changeling compile errors

### DIFF
--- a/code/modules/antagonists/changeling/bio_incubator.dm
+++ b/code/modules/antagonists/changeling/bio_incubator.dm
@@ -234,14 +234,15 @@
 	)
 	var/path = text2path(cell_id)
 	if(ispath(path, /datum/micro_organism/cell_line))
-		var/resulting_atom_path = initial(path.resulting_atom)
-		var/name = null
-		if(ispath(resulting_atom_path))
-			name = initial(resulting_atom_path.name)
-		if(!name)
-			name = get_nice_name_from_path(path)
-		entry["name"] = name
-		entry["desc"] = initial(path.desc)
+		var/datum/micro_organism/cell_line/cell_line = new path()
+		var/name_source = path
+		if(cell_line)
+			name_source = cell_line.resulting_atom || path
+			entry["desc"] = cell_line.desc
+			qdel(cell_line)
+		else
+			entry["desc"] = null
+		entry["name"] = get_nice_name_from_path(name_source)
 	else
 		entry["name"] = get_nice_name_from_path(cell_id)
 		entry["desc"] = null

--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -68,12 +68,12 @@
 	var/datum/cellular_emporium/cellular_emporium
 	/// A reference to our cellular emporium action (which opens the UI for the datum).
 	var/datum/action/cellular_emporium/emporium_action
-/// Coordinator for the genetic matrix UI.
-var/datum/genetic_matrix/genetic_matrix
-/// Action that opens the genetic matrix UI.
-var/datum/action/changeling/genetic_matrix/genetic_matrix_action
-/// Storage managing cytology cells, recipes, modules, and builds.
-var/datum/changeling_bio_incubator/bio_incubator
+	/// Coordinator for the genetic matrix UI.
+	var/datum/genetic_matrix/genetic_matrix
+	/// Action that opens the genetic matrix UI.
+	var/datum/action/changeling/genetic_matrix/genetic_matrix_action
+	/// Storage managing cytology cells, recipes, modules, and builds.
+	var/datum/changeling_bio_incubator/bio_incubator
 
 	/// UI displaying how many chems we have
 	var/atom/movable/screen/ling/chems/lingchemdisplay
@@ -124,17 +124,17 @@ var/datum/changeling_bio_incubator/bio_incubator
 /datum/antagonist/changeling/Destroy()
 	QDEL_NULL(emporium_action)
 	QDEL_NULL(cellular_emporium)
-QDEL_NULL(genetic_matrix_action)
-QDEL_NULL(genetic_matrix)
-QDEL_NULL(bio_incubator)
-current_profile = null
-return ..()
+	QDEL_NULL(genetic_matrix_action)
+	QDEL_NULL(genetic_matrix)
+	QDEL_NULL(bio_incubator)
+	current_profile = null
+	return ..()
 
 /datum/antagonist/changeling/on_gain()
-generate_name()
-create_emporium()
-create_bio_incubator()
-create_genetic_matrix()
+	generate_name()
+	create_emporium()
+	create_bio_incubator()
+	create_genetic_matrix()
 	create_innate_actions()
 	create_initial_profile()
 	if(give_objectives)

--- a/code/modules/antagonists/changeling/genetic_matrix.dm
+++ b/code/modules/antagonists/changeling/genetic_matrix.dm
@@ -148,7 +148,7 @@
 				return FALSE
 			changeling.assign_genetic_matrix_profile(build, null)
 			return TRUE
-		if(action == "set_build_module" || action == "set_build_ability")
+		if("set_build_module", "set_build_ability")
 			var/datum/changeling_bio_incubator/build/build = changeling.find_genetic_matrix_build(params["build"])
 			if(!build)
 				return FALSE
@@ -163,7 +163,7 @@
 				changeling.assign_genetic_matrix_module(build, null, slot)
 				return TRUE
 			return changeling.assign_genetic_matrix_module(build, module_identifier, slot)
-		if(action == "clear_build_module" || action == "clear_build_ability")
+		if("clear_build_module", "clear_build_ability")
 			var/datum/changeling_bio_incubator/build/build = changeling.find_genetic_matrix_build(params["build"])
 			if(!build)
 				return FALSE


### PR DESCRIPTION
## Summary
- ensure the changeling's genetic matrix, bio incubator, and related setup code live inside the antagonist datum
- fix the genetic matrix UI switch cases so module actions are matched as case values
- build bio incubator cell entries without using initial() on runtime paths

## Testing
- tools/build/build.sh dm-test *(fails: missing hypnagogic asset download, status 403)*

------
https://chatgpt.com/codex/tasks/task_e_68cdad8921c8832aba7be4a05ac58d39