### PR TITLE
Fix changeling genetic matrix compile issues

### DIFF
--- a/code/modules/antagonists/changeling/bio_incubator.dm
+++ b/code/modules/antagonists/changeling/bio_incubator.dm
@@ -368,6 +368,10 @@
 	if(changeling?.genetic_matrix)
 		SStgui.update_uis(changeling.genetic_matrix)
 
+/// Convenience helper for notifying listeners that build data changed.
+/datum/changeling_bio_incubator/proc/notify_builds_changed()
+	notify_update(BIO_INCUBATOR_UPDATE_BUILDS)
+
 /// Definition of a single build preset.
 /datum/changeling_bio_incubator/build
 	var/datum/changeling_bio_incubator/bio_incubator

--- a/code/modules/antagonists/changeling/genetic_matrix.dm
+++ b/code/modules/antagonists/changeling/genetic_matrix.dm
@@ -44,7 +44,8 @@
 	for(var/entry in matches)
 		if(!islist(entry))
 			continue
-		composer_preview += list(entry.Copy())
+		var/list/entry_list = entry
+		composer_preview += list(entry_list.Copy())
 
 /datum/genetic_matrix/proc/get_composer_preview()
 	var/list/output = list()
@@ -53,7 +54,8 @@
 	for(var/entry in composer_preview)
 		if(!islist(entry))
 			continue
-		output += list(entry.Copy())
+		var/list/entry_list = entry
+		output += list(entry_list.Copy())
 	return output
 
 /datum/genetic_matrix/ui_state(mob/user)
@@ -555,7 +557,7 @@
 	for(var/datum/changeling_bio_incubator/build/build as anything in bio_incubator.builds)
 		if(!build.assigned_profile)
 			build.assigned_profile = profile
-			bio_incubator.notify_update(BIO_INCUBATOR_UPDATE_BUILDS)
+		bio_incubator.notify_builds_changed()
 			break
 
 /// Handle updates when a DNA profile is removed.
@@ -568,4 +570,4 @@
 			build.assigned_profile = null
 			changed = TRUE
 	if(changed)
-		bio_incubator.notify_update(BIO_INCUBATOR_UPDATE_BUILDS)
+		bio_incubator.notify_builds_changed()

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -56,10 +56,6 @@
 
 	return ..()
 
-
-/mob/proc/get_cytology_cell_ids()
-	return list()
-
 /mob/New()
 	// This needs to happen IMMEDIATELY. I'm sorry :(
 	GenerateTag()


### PR DESCRIPTION
## Summary
- add a dedicated incubator helper for build update notifications
- ensure genetic matrix composer data is copied via typed lists
- remove the redundant mob cytology stub that conflicted with the global helper

## Testing
- python3 tools/validate_dme.py < tgstation.dme *(fails: existing include order)*

------
https://chatgpt.com/codex/tasks/task_e_68cdc4047cdc832abd2414810d71172c