### PR TITLE
Fix changeling profile assignment indentation

### DIFF
--- a/code/modules/antagonists/changeling/genetic_matrix.dm
+++ b/code/modules/antagonists/changeling/genetic_matrix.dm
@@ -557,7 +557,7 @@
 	for(var/datum/changeling_bio_incubator/build/build as anything in bio_incubator.builds)
 		if(!build.assigned_profile)
 			build.assigned_profile = profile
-		bio_incubator.notify_builds_changed()
+			bio_incubator.notify_builds_changed()
 			break
 
 /// Handle updates when a DNA profile is removed.


### PR DESCRIPTION
## Summary
- fix the indentation of the changeling profile assignment loop so the notifier and break stay within the conditional block

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cdc766cd68832a8a09f1a251eccc91