### PR TITLE
Fix changeling cytology harvest from species and swabbable sources

### DIFF
--- a/code/modules/antagonists/changeling/powers/harvest_cells.dm
+++ b/code/modules/antagonists/changeling/powers/harvest_cells.dm
@@ -9,16 +9,14 @@
 /datum/action/changeling/sting/harvest_cells/can_target_atom(mob/living/user, atom/target)
         if(isnull(target) || target == user)
                 return FALSE
-        if(istype(target, /mob/living))
-                return TRUE
-        return length(get_potential_cell_ids(target)) > 0
+        return has_any_cytology_cells(target)
 
 /datum/action/changeling/sting/harvest_cells/can_sting(mob/living/user, atom/target)
         if(!..())
                 return FALSE
         if(!target)
                 return FALSE
-        if(!length(get_potential_cell_ids(target)))
+        if(!has_any_cytology_cells(target))
                 user.balloon_alert(user, "no cytology cells!")
                 return FALSE
         return TRUE
@@ -33,6 +31,7 @@
                 return FALSE
         var/list/cell_ids = get_potential_cell_ids(target)
         if(!cell_ids.len)
+                user.balloon_alert(user, "no cytology cells!")
                 return FALSE
         var/added_any = FALSE
         for(var/cell_id in cell_ids)
@@ -52,6 +51,45 @@
                 var/mob/living/living_target = target
                 to_chat(living_target, span_warning("You feel the faintest prick."))
 
+/datum/action/changeling/sting/harvest_cells/proc/has_any_cytology_cells(atom/target)
+        if(!target)
+                return FALSE
+        var/list/direct_ids = target.get_cytology_cell_ids()
+        if(direct_ids?.len)
+                return TRUE
+        var/datum/biological_sample/sample = get_embedded_sample(target)
+        if(sample)
+                var/list/sample_ids = sample.get_cell_line_types()
+                if(sample_ids?.len)
+                        return TRUE
+        return is_swabbable_target(target)
+
+/datum/action/changeling/sting/harvest_cells/proc/is_swabbable_target(atom/target)
+        if(!target)
+                return FALSE
+        var/list/listeners = target._listen_lookup
+        if(!listeners)
+                return FALSE
+        return !!listeners[COMSIG_SWAB_FOR_SAMPLES]
+
+/datum/action/changeling/sting/harvest_cells/proc/collect_swabbable_samples(atom/target, list/cell_ids)
+        if(!target || !islist(cell_ids))
+                return
+        var/list/swabbed_items = list()
+        var/swab_result = SEND_SIGNAL(target, COMSIG_SWAB_FOR_SAMPLES, swabbed_items)
+        if(!(swab_result & COMPONENT_SWAB_FOUND))
+                return
+        for(var/entry in swabbed_items)
+                if(!istype(entry, /datum/biological_sample))
+                        qdel(entry)
+                        continue
+                var/datum/biological_sample/sample = entry
+                for(var/cell_id in sample.get_cell_line_types())
+                        if(!(cell_id in cell_ids))
+                                cell_ids += cell_id
+                qdel(sample)
+        return
+
 /datum/action/changeling/sting/harvest_cells/proc/get_potential_cell_ids(atom/target)
         var/list/cell_ids = list()
         if(!target)
@@ -65,6 +103,7 @@
                 for(var/entry in target.get_cytology_cell_ids())
                         if(!(entry in cell_ids))
                                 cell_ids += entry
+                collect_swabbable_samples(target, cell_ids)
         var/datum/biological_sample/sample = get_embedded_sample(target)
         if(sample)
                 for(var/entry in sample.get_cell_line_types())

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -4,6 +4,18 @@
 	update_body(is_creating = TRUE) //to update the carbon's new bodyparts appearance
 	living_flags &= ~STOP_OVERLAY_UPDATE_BODY_PARTS
 
+/mob/living/carbon/get_cytology_cell_ids()
+	var/list/ids = ..()
+	var/datum/dna/dna = src.dna
+	var/datum/species/species = dna?.species
+	if(species)
+		var/list/species_cells = species.get_cytology_cell_ids()
+		if(species_cells?.len)
+			for(var/entry in species_cells)
+				if(!(entry in ids))
+					ids += entry
+	return ids
+
 	register_context()
 
 	GLOB.carbon_list += src


### PR DESCRIPTION
## Summary
- make the harvest cells sting check for actual cytology sources, including swabbable containers, before using it
- reuse cytology cell ids defined on species so carbons like humans, vox, tajaran, and teshari provide their cells when harvested

## Testing
- bash tools/ci/check_grep.sh *(fails: repository already contains space indentation and lowertext() usage unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68cdd76e3b50832a9eb19640cf7dd977