### PR TITLE
Reuse existing bio incubator during harvest cells sting

### DIFF
--- a/code/modules/antagonists/changeling/powers/harvest_cells.dm
+++ b/code/modules/antagonists/changeling/powers/harvest_cells.dm
@@ -22,13 +22,14 @@
         return TRUE
 
 /datum/action/changeling/sting/harvest_cells/sting_action(mob/living/user, atom/target)
-        var/datum/antagonist/changeling/changeling = IS_CHANGELING(user)
-        if(!changeling)
-                return FALSE
-        changeling.create_bio_incubator()
-        var/datum/changeling_bio_incubator/incubator = changeling.bio_incubator
-        if(!incubator)
-                return FALSE
+	var/datum/antagonist/changeling/changeling = IS_CHANGELING(user)
+	if(!changeling)
+		return FALSE
+	var/datum/changeling_bio_incubator/incubator = changeling.bio_incubator
+	if(!incubator)
+		incubator = changeling.create_bio_incubator()
+	if(!incubator)
+		return FALSE
         var/list/cell_ids = get_potential_cell_ids(target)
         if(!cell_ids.len)
                 user.balloon_alert(user, "no cytology cells!")


### PR DESCRIPTION
## Summary
- reuse the changeling's existing bio-incubator during Harvest Cells stings instead of recreating it
- ensure cell collections persist so the Genetic Matrix continues to accumulate samples after repeated harvests

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ce470ded9c832aa3cafcd62b75e302