### PR TITLE
Allow collecting human biopsy samples

### DIFF
--- a/code/modules/mob/living/carbon/human/_species.dm
+++ b/code/modules/mob/living/carbon/human/_species.dm
@@ -151,6 +151,14 @@ GLOBAL_LIST_EMPTY(features_by_species)
 	var/list/inherent_factions
 	/// Cytology cell line identifiers linked to this species.
 	var/list/cytology_cell_ids
+	/// Biopsy configuration used when swabbing this species.
+	var/cytology_sample_table
+	/// Virus table used when generating biopsy samples for this species.
+	var/cytology_sample_virus_table = CELL_VIRUS_TABLE_GENERIC_MOB
+	/// How many cell lines are generated per biopsy sample.
+	var/cytology_sample_amount = 1
+	/// Chance for biopsy samples from this species to contain a virus.
+	var/cytology_sample_virus_chance = 5
 
 	///What gas does this species breathe? Used by suffocation screen alerts, most of actual gas breathing is handled by mutantlungs. See [life.dm][code/modules/mob/living/carbon/human/life.dm]
 	var/breathid = GAS_O2
@@ -436,7 +444,9 @@ GLOBAL_LIST_EMPTY(features_by_species)
 	for(var/language in gaining_holder.blocked_understanding)
 		human_who_gained_species.add_blocked_language(language, UNDERSTOOD_LANGUAGE, LANGUAGE_SPECIES)
 	if(regenerate_icons)
-		human_who_gained_species.regenerate_icons()
+	        human_who_gained_species.regenerate_icons()
+
+	human_who_gained_species.update_cytology_samples()
 
 	SEND_SIGNAL(human_who_gained_species, COMSIG_SPECIES_GAIN, src, old_species)
 
@@ -2226,5 +2236,10 @@ GLOBAL_LIST_EMPTY(features_by_species)
 
 /datum/species/proc/get_cytology_cell_ids()
 	if(!cytology_cell_ids)
-		return list()
+	        return list()
 	return cytology_cell_ids.Copy()
+
+/datum/species/proc/get_cytology_swab_config()
+	if(!cytology_sample_table)
+	        return null
+	return list(cytology_sample_table, cytology_sample_virus_table, cytology_sample_amount, cytology_sample_virus_chance)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1,3 +1,6 @@
+/mob/living/carbon/human
+	var/list/cytology_swab_element_args
+
 /mob/living/carbon/human/Initialize(mapload)
 	add_verb(src, /mob/living/proc/mob_sleep)
 	add_verb(src, /mob/living/proc/toggle_resting)
@@ -37,6 +40,17 @@
 	GLOB.human_list += src
 	ADD_TRAIT(src, TRAIT_CAN_MOUNT_HUMANS, INNATE_TRAIT)
 	ADD_TRAIT(src, TRAIT_CAN_MOUNT_CYBORGS, INNATE_TRAIT)
+	update_cytology_samples()
+
+/mob/living/carbon/human/proc/update_cytology_samples()
+	if(cytology_swab_element_args)
+	        RemoveElement(/datum/element/swabable, arglist(cytology_swab_element_args))
+	        cytology_swab_element_args = null
+	var/list/swab_configuration = dna?.species?.get_cytology_swab_config()
+	if(!swab_configuration)
+	        return
+	AddElement(/datum/element/swabable, arglist(swab_configuration))
+	cytology_swab_element_args = swab_configuration.Copy()
 
 /mob/living/carbon/human/proc/setup_physiology()
 	physiology = new()

--- a/code/modules/mob/living/carbon/human/species_types/humans.dm
+++ b/code/modules/mob/living/carbon/human/species_types/humans.dm
@@ -2,12 +2,13 @@
 	name = "\improper Human"
 	id = SPECIES_HUMAN
 	inherent_traits = list(
-		TRAIT_USES_SKINTONES,
+	        TRAIT_USES_SKINTONES,
 	)
 	skinned_type = /obj/item/stack/sheet/animalhide/human
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT
 	payday_modifier = 1.1
 	cytology_cell_ids = list(/datum/micro_organism/cell_line/human)
+	cytology_sample_table = CELL_LINE_TABLE_HUMAN
 
 /datum/species/human/prepare_human_for_preview(mob/living/carbon/human/human)
 	human.set_haircolor("#bb9966", update = FALSE) // brown


### PR DESCRIPTION
## Summary
- add a biopsy swab configuration to species data and expose the human table
- refresh a human's swabbable sample when they initialize or change species
- ensure the biopsy tool can collect a cell sample from live humans

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ce54b4e6a8832a94a58f34dead56f9