### PR TITLE
Refactor changeling Harvest Cells to use cell line tables

### DIFF
--- a/code/modules/mob/living/basic/farm_animals/chicken/chicken.dm
+++ b/code/modules/mob/living/basic/farm_animals/chicken/chicken.dm
@@ -32,7 +32,7 @@ GLOBAL_VAR_INIT(chicken_count, 0)
 	pass_flags = PASSTABLE | PASSMOB
 	mob_size = MOB_SIZE_SMALL
 	gold_core_spawnable = FRIENDLY_SPAWN
-        cytology_cell_line = /datum/micro_organism/cell_line/chicken
+       cell_line = CELL_LINE_TABLE_CHICKEN
 
 	ai_controller = /datum/ai_controller/basic_controller/chicken
 

--- a/code/modules/mob/living/basic/farm_animals/cow/_cow.dm
+++ b/code/modules/mob/living/basic/farm_animals/cow/_cow.dm
@@ -27,7 +27,7 @@
 	gold_core_spawnable = FRIENDLY_SPAWN
 	blood_volume = BLOOD_VOLUME_NORMAL
 	ai_controller = /datum/ai_controller/basic_controller/cow
-        cytology_cell_line = /datum/micro_organism/cell_line/cow
+       cell_line = CELL_LINE_TABLE_COW
 	/// what this cow munches on, and what can be used to tame it.
 	var/list/food_types = list(/obj/item/food/grown/wheat)
 	/// message sent when tamed

--- a/code/modules/mob/living/basic/farm_animals/goat/_goat.dm
+++ b/code/modules/mob/living/basic/farm_animals/goat/_goat.dm
@@ -34,7 +34,7 @@
 	blood_volume = BLOOD_VOLUME_NORMAL
 
 	ai_controller = /datum/ai_controller/basic_controller/goat
-        cytology_cell_line = /datum/micro_organism/cell_line/goat
+       cell_line = CELL_LINE_TABLE_GOAT
 	/// How often will we develop an evil gleam in our eye?
 	var/gleam_delay = 20 SECONDS
 	/// Time until we can next gleam evilly

--- a/code/modules/mob/living/basic/space_fauna/carp/carp.dm
+++ b/code/modules/mob/living/basic/space_fauna/carp/carp.dm
@@ -48,8 +48,8 @@
 
 	/// If true we will run away from attackers even at full health
 	var/cowardly = FALSE
-	/// Cytology cells you can swab from this creature
-	var/cell_line = CELL_LINE_TABLE_CARP
+       /// Cytology cells you can swab from this creature
+       cell_line = CELL_LINE_TABLE_CARP
 	/// What colour is our 'healing' outline?
 	var/regenerate_colour = COLOR_PALE_GREEN
 	/// Ability which lets carp teleport around

--- a/code/modules/mob/living/carbon/human/_species.dm
+++ b/code/modules/mob/living/carbon/human/_species.dm
@@ -116,8 +116,8 @@ GLOBAL_LIST_EMPTY(features_by_species)
 	var/stunmod = 1
 	///multiplier for money paid at payday
 	var/payday_modifier = 1.0
-	/// Cytology cell line identifier supplied when harvesting this species.
-	var/cytology_cell_line
+       /// Cytology cell line table identifier supplied when harvesting this species.
+       var/cell_line
 	///Base electrocution coefficient.  Basically a multiplier for damage from electrocutions.
 	var/siemens_coeff = 1
 	///To use MUTCOLOR with a fixed color that's independent of the mcolor feature in DNA.

--- a/code/modules/mob/living/carbon/human/species_types/humans.dm
+++ b/code/modules/mob/living/carbon/human/species_types/humans.dm
@@ -7,7 +7,7 @@
 	skinned_type = /obj/item/stack/sheet/animalhide/human
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT
 	payday_modifier = 1.1
-        cytology_cell_line = /datum/micro_organism/cell_line/human
+       cell_line = CELL_LINE_TABLE_HUMAN
 
 /datum/species/human/prepare_human_for_preview(mob/living/carbon/human/human)
 	human.set_haircolor("#bb9966", update = FALSE) // brown

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -108,8 +108,8 @@
 	var/mob_size = MOB_SIZE_HUMAN
 	/// List of biotypes the mob belongs to. Used by diseases and reagents mainly.
 	var/mob_biotypes = MOB_ORGANIC
-	/// Cytology cell line identifier harvested by bioengineering abilities.
-	var/cytology_cell_line
+       /// Cytology cell line table identifier harvested by bioengineering abilities.
+       var/cell_line
 	/// The type of respiration the mob is capable of doing. Used by adjustOxyLoss.
 	var/mob_respiration_type = RESPIRATION_OXYGEN
 	///more or less efficiency to metabolize helpful/harmful reagents and regulate body temperature..

--- a/modular_nova/modules/better_vox/code/vox_species.dm
+++ b/modular_nova/modules/better_vox/code/vox_species.dm
@@ -20,7 +20,7 @@
 	outfit_important_for_life = /datum/outfit/vox
 	species_language_holder = /datum/language_holder/vox
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT
-        cytology_cell_line = /datum/micro_organism/cell_line/vox
+       cell_line = CELL_LINE_TABLE_VOX
 
 	// Vox are cold resistant, but also heat sensitive
 	bodytemp_heat_damage_limit = (BODYTEMP_HEAT_DAMAGE_LIMIT - 15) // being cold resistant, should make you heat sensitive actual effect ingame isn't much

--- a/modular_nova/modules/customization/modules/mob/living/carbon/human/species/tajaran.dm
+++ b/modular_nova/modules/customization/modules/mob/living/carbon/human/species/tajaran.dm
@@ -17,7 +17,7 @@
 	species_language_holder = /datum/language_holder/tajaran
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT
 	examine_limb_id = SPECIES_MAMMAL
-        cytology_cell_line = /datum/micro_organism/cell_line/tajaran
+       cell_line = CELL_LINE_TABLE_TAJARAN
 	bodypart_overrides = list(
 		BODY_ZONE_HEAD = /obj/item/bodypart/head/mutant,
 		BODY_ZONE_CHEST = /obj/item/bodypart/chest/mutant,

--- a/modular_nova/modules/customization/modules/mob/living/carbon/human/species/vox.dm
+++ b/modular_nova/modules/customization/modules/mob/living/carbon/human/species/vox.dm
@@ -31,7 +31,7 @@
 		BODY_ZONE_L_LEG = /obj/item/bodypart/leg/left/mutant/vox,
 		BODY_ZONE_R_LEG = /obj/item/bodypart/leg/right/mutant/vox,
 	)
-        cytology_cell_line = /datum/micro_organism/cell_line/vox
+       cell_line = CELL_LINE_TABLE_VOX
 	custom_worn_icons = list(
 		LOADOUT_ITEM_HEAD = VOX_HEAD_ICON,
 		LOADOUT_ITEM_MASK = VOX_MASK_ICON,

--- a/modular_nova/modules/teshari/code/_teshari.dm
+++ b/modular_nova/modules/teshari/code/_teshari.dm
@@ -46,7 +46,7 @@
 		BODY_ZONE_L_LEG = /obj/item/bodypart/leg/left/mutant/teshari,
 		BODY_ZONE_R_LEG = /obj/item/bodypart/leg/right/mutant/teshari,
 	)
-        cytology_cell_line = /datum/micro_organism/cell_line/teshari
+       cell_line = CELL_LINE_TABLE_TESHARI
 
 /datum/species/teshari/get_default_mutant_bodyparts()
 	return list(


### PR DESCRIPTION
## Summary
- allow Harvest Cells to pull cytology entries from mob `cell_line` tables or species-level definitions via the global table lookup
- replace `cytology_cell_line` with `cell_line` on living mobs/species and assign tables for cows, chickens, goats, carp, and supported player species

## Testing
- `python tools/run_dreamchecker.py` *(fails: file not found in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68ce7ee58630832a93f4be43a535ab34