### PR TITLE
Support activating changeling genetic matrix builds

### DIFF
--- a/code/__DEFINES/antagonists.dm
+++ b/code/__DEFINES/antagonists.dm
@@ -420,6 +420,14 @@ GLOBAL_LIST_INIT(human_invader_antagonists, list(
 /// Changeling abilities with DNA cost = this are not obtainable by changelings - either used for secret unlockable or abstract abilities
 #define CHANGELING_POWER_UNOBTAINABLE -2
 
+/// Genetic matrix module identifiers for convenience when checking upgrades
+#define CHANGELING_MODULE_PREDATORY_HOWL "matrix_predatory_howl"
+#define CHANGELING_MODULE_SYMBIOTIC_OVERGROWTH "matrix_symbiotic_overgrowth"
+#define CHANGELING_MODULE_FEATHERED_VEIL "matrix_feathered_veil"
+#define CHANGELING_MODULE_PREDATOR_SINEW "matrix_predator_sinew"
+#define CHANGELING_MODULE_VOID_CARAPACE "matrix_void_carapace"
+#define CHANGELING_MODULE_ADRENAL_SPIKE "matrix_adrenal_spike"
+
 /// For changelings, this is how many recent say lines are retained when absorbing a mob
 #define LING_ABSORB_RECENT_SPEECH 8
 // Various abductor equipment modes.

--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -980,6 +980,7 @@
 	user.regenerate_icons()
 	user.name = user.get_visible_name()
 	current_profile = chosen_profile
+	sync_active_genetic_build_for_profile(chosen_profile)
 	// NOVA EDIT START
 	user.updateappearance(mutcolor_update = TRUE, eyeorgancolor_update = TRUE)
 	user.regenerate_icons()

--- a/code/modules/antagonists/changeling/genetic_matrix.dm
+++ b/code/modules/antagonists/changeling/genetic_matrix.dm
@@ -73,7 +73,9 @@
 	changeling.ensure_genetic_matrix_setup()
 	changeling.update_genetic_matrix_unlocks()
 	changeling.prune_genetic_matrix_assignments()
+	var/datum/changeling_bio_incubator/build/active_build = changeling.get_active_genetic_matrix_build()
 	data["builds"] = changeling.get_genetic_matrix_builds_data()
+	data["activeBuild"] = active_build ? REF(active_build) : null
 	data["profiles"] = changeling.get_genetic_matrix_profile_catalog()
 	data["modules"] = changeling.get_genetic_matrix_module_catalog()
 	data["abilities"] = changeling.get_genetic_matrix_ability_catalog()
@@ -112,10 +114,15 @@
 			var/datum/changeling_bio_incubator/build/build = changeling.find_genetic_matrix_build(params["build"])
 			if(!build)
 				return FALSE
-			if(tgui_alert(user, "Delete build \"[build.name]\"?", "Remove Build", list("Delete", "Cancel")) != "Delete")
+                        if(tgui_alert(user, "Delete build \"[build.name]\"?", "Remove Build", list("Delete", "Cancel")) != "Delete")
 				return FALSE
 			changeling.remove_genetic_matrix_build(build)
 			return TRUE
+		if("activate_build")
+			var/datum/changeling_bio_incubator/build/build = changeling.find_genetic_matrix_build(params["build"])
+			if(!build)
+				return FALSE
+			return changeling.activate_genetic_matrix_build(build)
 		if("rename_build")
 			var/datum/changeling_bio_incubator/build/build = changeling.find_genetic_matrix_build(params["build"])
 			if(!build)
@@ -189,6 +196,7 @@
 		if("readapt_standard")
 			return changeling.readapt()
 	return FALSE
+
 
 /datum/action/changeling/genetic_matrix
 	name = "Genetic Matrix"
@@ -368,6 +376,52 @@
 /// Clear all assignments from a specific build without deleting it.
 /datum/antagonist/changeling/proc/clear_genetic_matrix_build(datum/changeling_bio_incubator/build/build)
 	bio_incubator?.clear_build(build)
+
+/// Retrieve the build currently active for this changeling.
+/datum/antagonist/changeling/proc/get_active_genetic_matrix_build()
+	return bio_incubator ? bio_incubator.get_active_build() : null
+
+/// Set the changeling's active build preset.
+/datum/antagonist/changeling/proc/activate_genetic_matrix_build(datum/changeling_bio_incubator/build/build)
+	return bio_incubator ? bio_incubator.set_active_build(build) : FALSE
+
+/// Return the list of module identifiers assigned to the active build.
+/datum/antagonist/changeling/proc/get_active_genetic_matrix_modules()
+	var/list/modules = list()
+	var/datum/changeling_bio_incubator/build/active_build = get_active_genetic_matrix_build()
+	if(!active_build)
+		return modules
+	active_build.ensure_slot_capacity()
+	for(var/module_id in active_build.module_ids)
+		if(module_id)
+			modules += module_id
+	return modules
+
+/// Determine whether the active build includes a specific module identifier.
+/datum/antagonist/changeling/proc/has_active_genetic_matrix_module(module_identifier)
+	if(isnull(module_identifier) || !bio_incubator)
+		return FALSE
+	var/datum/changeling_bio_incubator/build/active_build = get_active_genetic_matrix_build()
+	if(!active_build)
+		return FALSE
+	var/id_text = bio_incubator.sanitize_module_id(module_identifier)
+	if(!id_text)
+		return FALSE
+	active_build.ensure_slot_capacity()
+	for(var/assigned in active_build.module_ids)
+		if(assigned == id_text)
+			return TRUE
+	return FALSE
+
+/// Align the active build to one associated with the provided profile, if available.
+/datum/antagonist/changeling/proc/sync_active_genetic_build_for_profile(datum/changeling_profile/profile)
+	if(!bio_incubator)
+		return
+	var/datum/changeling_bio_incubator/build/matching = bio_incubator.find_build_for_profile(profile)
+	if(matching)
+		bio_incubator.set_active_build(matching)
+	else
+		bio_incubator.ensure_default_build()
 
 /// Assign a DNA profile to a build.
 /datum/antagonist/changeling/proc/assign_genetic_matrix_profile(datum/changeling_bio_incubator/build/build, datum/changeling_profile/profile)


### PR DESCRIPTION
## Summary
- track the active genetic matrix build within the bio-incubator, including serialization, pruning, and helper lookups
- surface the active build to changeling backend logic with activation/sync helpers and profile change integration
- refresh the Genetic Matrix TGUI to highlight the active build, default selection to it, and provide an activation control

## Testing
- npm run tgui:lint *(fails: existing biome lint violations in tgfont assets and shared utilities)*

------
https://chatgpt.com/codex/tasks/task_e_68ce89d06cb0832ab124a03df44fb78a