### PR TITLE
Fix changeling ability naming fallback and cytology indentation

### DIFF
--- a/code/modules/antagonists/changeling/bio_incubator.dm
+++ b/code/modules/antagonists/changeling/bio_incubator.dm
@@ -10,6 +10,16 @@
 #define BIO_INCUBATOR_SLOT_KEY "key"
 #define BIO_INCUBATOR_SLOT_FLEX "flex"
 
+/// Returns a human readable name for a datum path or text identifier.
+/proc/changeling_get_nice_name_from_path(path_input)
+	var/text_value = istext(path_input) ? path_input : "[path_input]"
+	var/list/split_path = splittext(text_value, "/")
+	if(!split_path.len)
+		return text_value
+	var/raw = split_path[split_path.len]
+	raw = replacetext(raw, "_", " ")
+	return capitalize(raw)
+
 /// Stores changeling genetic matrix inventory and build configuration.
 /datum/changeling_bio_incubator
 	/// Owning changeling datum.
@@ -363,13 +373,7 @@
 	return entry
 
 /datum/changeling_bio_incubator/proc/get_nice_name_from_path(path_input)
-	var/text_value = istext(path_input) ? path_input : "[path_input]"
-	var/list/split_path = splittext(text_value, "/")
-	if(!split_path.len)
-		return text_value
-	var/raw = split_path[split_path.len]
-	raw = replacetext(raw, "_", " " )
-	return capitalize(raw)
+	return changeling_get_nice_name_from_path(path_input)
 
 /datum/changeling_bio_incubator/proc/add_recipe(recipe_identifier)
 	var/recipe_id = sanitize_module_id(recipe_identifier)

--- a/code/modules/antagonists/changeling/genetic_matrix.dm
+++ b/code/modules/antagonists/changeling/genetic_matrix.dm
@@ -533,7 +533,10 @@
 			for(var/ability_path in required_abilities)
 				var/list/ability_data = get_genetic_matrix_module_data_from_path(ability_path)
 				if(!islist(ability_data))
-					ability_data = list("name" = get_nice_name_from_path(ability_path))
+					var/nice_name = changeling_get_nice_name_from_path(ability_path)
+					if(incubator)
+						nice_name = incubator.get_nice_name_from_path(ability_path)
+					ability_data = list("name" = nice_name)
 				ability_entries += list(list(
 					"id" = "[ability_path]",
 					"name" = ability_data["name"],

--- a/code/modules/research/xenobiology/vatgrowing/samples/cell_lines/common.dm
+++ b/code/modules/research/xenobiology/vatgrowing/samples/cell_lines/common.dm
@@ -5,8 +5,8 @@
 ////////////////////////////////
 
 /datum/micro_organism/cell_line/mouse //nuisance cell line designed to complicate the growing of animal type cell lines.
-desc = "Murine cells"
-required_reagents = list(/datum/reagent/consumable/nutriment/protein)
+	desc = "Murine cells"
+	required_reagents = list(/datum/reagent/consumable/nutriment/protein)
 	supplementary_reagents = list(
 		/datum/reagent/growthserum = 2,
 		/datum/reagent/consumable/liquidgibs = 2,
@@ -25,8 +25,8 @@ required_reagents = list(/datum/reagent/consumable/nutriment/protein)
 
 	virus_suspectibility = 2
 	growth_rate = VAT_GROWTH_RATE
-resulting_atom = /mob/living/basic/mouse
-resulting_atom_count = 2
+	resulting_atom = /mob/living/basic/mouse
+	resulting_atom_count = 2
 
 /datum/micro_organism/cell_line/human
 	desc = "Human somatic cells"


### PR DESCRIPTION
## Summary
- add a shared changeling helper to format module path names
- use the helper when displaying recipe ability requirements
- restore the lost indentation on the murine cell line definition

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ce9dd5d29c832aa985a66e3ebc41f9