### PR TITLE
Refactor changeling cell handling

### DIFF
--- a/code/_globalvars/lists/xenobiology.dm
+++ b/code/_globalvars/lists/xenobiology.dm
@@ -79,11 +79,6 @@ GLOBAL_LIST_INIT_TYPED(cell_line_tables, /list, list(
 	CELL_LINE_TABLE_QUEEN_BEE = list(/datum/micro_organism/cell_line/queen_bee = 1),
 	CELL_LINE_TABLE_BUTTERFLY = list(/datum/micro_organism/cell_line/butterfly = 1),
 	CELL_LINE_TABLE_MEGA_ARACHNID = list(/datum/micro_organism/cell_line/mega_arachnid = 1),
-	CELL_LINE_TABLE_VOX = list(/datum/micro_organism/cell_line/vox = 1),
-	CELL_LINE_TABLE_TAJARAN = list(/datum/micro_organism/cell_line/tajaran = 1),
-	CELL_LINE_TABLE_TESHARI = list(/datum/micro_organism/cell_line/teshari = 1),
-	CELL_LINE_TABLE_COLOSSUS = list(/datum/micro_organism/cell_line/colossus = 1),
-	CELL_LINE_TABLE_RARE_PREDATOR = list(/datum/micro_organism/cell_line/rare_predator = 1),
 	CELL_LINE_TABLE_ALGAE = list(
 		/datum/micro_organism/cell_line/frog = 2,
 		/datum/micro_organism/cell_line/mega_arachnid = 1,

--- a/code/modules/antagonists/changeling/cell_registry.dm
+++ b/code/modules/antagonists/changeling/cell_registry.dm
@@ -1,0 +1,233 @@
+#define CHANGELING_CELL_REGISTRY_NAME "name"
+#define CHANGELING_CELL_REGISTRY_DESC "desc"
+#define CHANGELING_CELL_REGISTRY_KEYWORDS "keywords"
+#define CHANGELING_CELL_REGISTRY_TYPES "types"
+#define CHANGELING_CELL_REGISTRY_SPECIES "species"
+
+#define CHANGELING_CELL_ID_HUMAN "human"
+#define CHANGELING_CELL_ID_VOX "vox"
+#define CHANGELING_CELL_ID_TAJARAN "tajaran"
+#define CHANGELING_CELL_ID_TESHARI "teshari"
+#define CHANGELING_CELL_ID_CHICKEN "chicken"
+#define CHANGELING_CELL_ID_COW "cow"
+#define CHANGELING_CELL_ID_GOAT "goat"
+#define CHANGELING_CELL_ID_RARE_PREDATOR "rare_predator"
+#define CHANGELING_CELL_ID_COLOSSUS "colossus"
+
+GLOBAL_LIST_INIT(changeling_cell_registry, list(
+    CHANGELING_CELL_ID_HUMAN = list(
+        CHANGELING_CELL_REGISTRY_NAME = "Human Crew",
+        CHANGELING_CELL_REGISTRY_DESC = "Baseline Nanotrasen crew biomatter.",
+        CHANGELING_CELL_REGISTRY_SPECIES = list(SPECIES_HUMAN),
+        CHANGELING_CELL_REGISTRY_KEYWORDS = list("human", "crew"),
+        CHANGELING_CELL_REGISTRY_TYPES = list(/mob/living/carbon/human),
+    ),
+    CHANGELING_CELL_ID_VOX = list(
+        CHANGELING_CELL_REGISTRY_NAME = "Vox",
+        CHANGELING_CELL_REGISTRY_DESC = "Avian cortical cluster harvested from Vox biology.",
+        CHANGELING_CELL_REGISTRY_SPECIES = list(SPECIES_VOX, SPECIES_VOX_PRIMALIS),
+        CHANGELING_CELL_REGISTRY_KEYWORDS = list("vox"),
+    ),
+    CHANGELING_CELL_ID_TAJARAN = list(
+        CHANGELING_CELL_REGISTRY_NAME = "Tajaran",
+        CHANGELING_CELL_REGISTRY_DESC = "Feline survival tissues gleaned from Tajaran hosts.",
+        CHANGELING_CELL_REGISTRY_SPECIES = list(SPECIES_TAJARAN),
+        CHANGELING_CELL_REGISTRY_KEYWORDS = list("tajaran"),
+    ),
+    CHANGELING_CELL_ID_TESHARI = list(
+        CHANGELING_CELL_REGISTRY_NAME = "Teshari",
+        CHANGELING_CELL_REGISTRY_DESC = "Lightweight musculature adapted for Teshari sprinters.",
+        CHANGELING_CELL_REGISTRY_SPECIES = list(SPECIES_TESHARI),
+        CHANGELING_CELL_REGISTRY_KEYWORDS = list("teshari"),
+    ),
+    CHANGELING_CELL_ID_CHICKEN = list(
+        CHANGELING_CELL_REGISTRY_NAME = "Chicken",
+        CHANGELING_CELL_REGISTRY_DESC = "Docile barnyard avian samples.",
+        CHANGELING_CELL_REGISTRY_TYPES = list(/mob/living/basic/chicken),
+        CHANGELING_CELL_REGISTRY_KEYWORDS = list("chicken", "hen"),
+    ),
+    CHANGELING_CELL_ID_COW = list(
+        CHANGELING_CELL_REGISTRY_NAME = "Cow",
+        CHANGELING_CELL_REGISTRY_DESC = "Heavy livestock tissue lattice.",
+        CHANGELING_CELL_REGISTRY_TYPES = list(/mob/living/basic/cow),
+        CHANGELING_CELL_REGISTRY_KEYWORDS = list("cow", "cattle"),
+    ),
+    CHANGELING_CELL_ID_GOAT = list(
+        CHANGELING_CELL_REGISTRY_NAME = "Goat",
+        CHANGELING_CELL_REGISTRY_DESC = "Stubborn grazer tissues ideal for endurance grafts.",
+        CHANGELING_CELL_REGISTRY_TYPES = list(/mob/living/basic/goat),
+        CHANGELING_CELL_REGISTRY_KEYWORDS = list("goat"),
+    ),
+    CHANGELING_CELL_ID_RARE_PREDATOR = list(
+        CHANGELING_CELL_REGISTRY_NAME = "Apex Predator",
+        CHANGELING_CELL_REGISTRY_DESC = "Hyperdense combat fibers from rare predators.",
+        CHANGELING_CELL_REGISTRY_TYPES = list(
+            /mob/living/basic/carp,
+            /mob/living/basic/carp/megacarp,
+            /mob/living/simple_animal/hostile/megafauna,
+        ),
+        CHANGELING_CELL_REGISTRY_KEYWORDS = list("predator", "megafauna", "carp", "dragon", "goliath"),
+    ),
+    CHANGELING_CELL_ID_COLOSSUS = list(
+        CHANGELING_CELL_REGISTRY_NAME = "Colossus",
+        CHANGELING_CELL_REGISTRY_DESC = "Crystalline lattice fragments from a lavaland colossus.",
+        CHANGELING_CELL_REGISTRY_TYPES = list(/mob/living/simple_animal/hostile/megafauna/colossus),
+        CHANGELING_CELL_REGISTRY_KEYWORDS = list("colossus"),
+    ),
+))
+
+/proc/changeling_get_cell_registry()
+    return GLOB.changeling_cell_registry
+
+/proc/changeling_normalize_match_text(text)
+    var/value = trimtext(isnull(text) ? "" : "[text]")
+    if(!length(value))
+        return ""
+    return lowertext(value)
+
+/proc/changeling_text_matches(a, b)
+    var/normalized_a = changeling_normalize_match_text(a)
+    var/normalized_b = changeling_normalize_match_text(b)
+    if(!length(normalized_a) || !length(normalized_b))
+        return FALSE
+    return normalized_a == normalized_b
+
+/proc/changeling_cell_id_exists(cell_identifier)
+    var/cell_id = changeling_normalize_cell_id(cell_identifier)
+    return !isnull(cell_id)
+
+/proc/changeling_normalize_cell_id(cell_identifier)
+    if(isnull(cell_identifier))
+        return null
+    var/text_value = changeling_normalize_match_text(cell_identifier)
+    if(!length(text_value))
+        return null
+    if(!(text_value in changeling_get_cell_registry()))
+        return null
+    return text_value
+
+/proc/changeling_get_cell_metadata(cell_identifier)
+    var/cell_id = changeling_normalize_cell_id(cell_identifier)
+    if(isnull(cell_id))
+        return null
+    var/list/registry = changeling_get_cell_registry()
+    var/list/entry = registry?[cell_id]
+    return islist(entry) ? entry : null
+
+/proc/changeling_get_cell_display_name(cell_identifier)
+    var/list/entry = changeling_get_cell_metadata(cell_identifier)
+    if(entry)
+        var/name = entry[CHANGELING_CELL_REGISTRY_NAME]
+        if(length(name))
+            return "[name]"
+    var/text_value = replacetext("[cell_identifier]", "_", " ")
+    return capitalize(text_value)
+
+/proc/changeling_registry_entry_matches_name(list/entry, normalized_name)
+    if(!islist(entry) || !length(normalized_name))
+        return FALSE
+    var/entry_name = changeling_normalize_match_text(entry[CHANGELING_CELL_REGISTRY_NAME])
+    if(length(entry_name) && findtext(normalized_name, entry_name))
+        return TRUE
+    var/list/keywords = entry[CHANGELING_CELL_REGISTRY_KEYWORDS]
+    if(islist(keywords))
+        for(var/keyword in keywords)
+            var/normalized_keyword = changeling_normalize_match_text(keyword)
+            if(!length(normalized_keyword))
+                continue
+            if(findtext(normalized_name, normalized_keyword))
+                return TRUE
+    return FALSE
+
+/proc/changeling_registry_entry_matches_species(list/entry, species_id)
+    var/list/species_ids = entry[CHANGELING_CELL_REGISTRY_SPECIES]
+    if(!islist(species_ids) || !species_ids.len)
+        return FALSE
+    var/normalized_species = changeling_normalize_match_text(species_id)
+    if(!length(normalized_species))
+        return FALSE
+    for(var/species_candidate in species_ids)
+        if(changeling_text_matches(normalized_species, species_candidate))
+            return TRUE
+    return FALSE
+
+/proc/changeling_registry_entry_matches_type(list/entry, mob/living/target)
+    var/list/type_list = entry[CHANGELING_CELL_REGISTRY_TYPES]
+    if(!islist(type_list) || !type_list.len)
+        return FALSE
+    for(var/path/type_path in type_list)
+        if(ispath(type_path) && istype(target, type_path))
+            return TRUE
+    return FALSE
+
+/proc/changeling_get_species_id_for_mob(mob/living/target)
+    if(!target)
+        return null
+    if(ishuman(target))
+        var/mob/living/carbon/human/human_target = target
+        return human_target.dna?.species?.id
+    if(iscarbon(target))
+        var/mob/living/carbon/carbon_target = target
+        return carbon_target.dna?.species?.id
+    return null
+
+/proc/changeling_get_match_names_for_mob(mob/living/target)
+    var/list/names = list()
+    if(!target)
+        return names
+    if(ishuman(target))
+        var/mob/living/carbon/human/human_target = target
+        if(length(human_target.real_name))
+            var/normalized_real_name = changeling_normalize_match_text(human_target.real_name)
+            if(length(normalized_real_name))
+                names += normalized_real_name
+    var/normalized_name = changeling_normalize_match_text(target.name)
+    if(length(normalized_name))
+        names += normalized_name
+    return names
+
+/proc/changeling_get_cell_ids_from_name(sample_name)
+    var/list/results = list()
+    var/normalized_name = changeling_normalize_match_text(sample_name)
+    if(!length(normalized_name))
+        return results
+    var/list/registry = changeling_get_cell_registry()
+    for(var/cell_id in registry)
+        var/list/entry = registry[cell_id]
+        if(!islist(entry))
+            continue
+        if(changeling_registry_entry_matches_name(entry, normalized_name))
+            if(!(cell_id in results))
+                results += cell_id
+    return results
+
+/proc/changeling_get_cell_ids_from_mob(mob/living/target)
+    var/list/results = list()
+    if(!target)
+        return results
+    var/list/registry = changeling_get_cell_registry()
+    var/species_id = changeling_get_species_id_for_mob(target)
+    var/list/match_names = changeling_get_match_names_for_mob(target)
+    for(var/cell_id in registry)
+        var/list/entry = registry[cell_id]
+        if(!islist(entry))
+            continue
+        if(changeling_registry_entry_matches_species(entry, species_id))
+            if(!(cell_id in results))
+                results += cell_id
+            continue
+        if(changeling_registry_entry_matches_type(entry, target))
+            if(!(cell_id in results))
+                results += cell_id
+            continue
+        if(!islist(match_names))
+            continue
+        for(var/name_entry in match_names)
+            if(!istext(name_entry))
+                continue
+            if(changeling_registry_entry_matches_name(entry, name_entry))
+                if(!(cell_id in results))
+                    results += cell_id
+                break
+    return results
+

--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -666,13 +666,12 @@
 		if(!push_out_profile())
 			return
 
-	if(!first_profile)
-		first_profile = new_profile
-		current_profile = first_profile
+        if(!first_profile)
+                first_profile = new_profile
+                current_profile = first_profile
 
-	stored_profiles += new_profile
-	on_genetic_matrix_profile_added(new_profile)
-	absorbed_count++
+        stored_profiles += new_profile
+        absorbed_count++
 
 /*
  * Create a new profile from the given [profile_target]
@@ -695,11 +694,10 @@
 /datum/antagonist/changeling/proc/remove_profile(mob/living/carbon/human/profile_target, force = FALSE)
 	for(var/datum/changeling_profile/found_profile as anything in stored_profiles)
 		if(profile_target.real_name == found_profile.name)
-			if(found_profile.protected && !force)
-				continue
-			stored_profiles -= found_profile
-			on_genetic_matrix_profile_removed(found_profile)
-			qdel(found_profile)
+                        if(found_profile.protected && !force)
+                                continue
+                        stored_profiles -= found_profile
+                        qdel(found_profile)
 
 /*
  * Removes the highest changeling profile from the list
@@ -714,11 +712,10 @@
 			profile_to_remove = found_profile
 			break
 
-	if(profile_to_remove)
-		stored_profiles -= profile_to_remove
-		on_genetic_matrix_profile_removed(profile_to_remove)
-		qdel(profile_to_remove)
-		return TRUE
+        if(profile_to_remove)
+                stored_profiles -= profile_to_remove
+                qdel(profile_to_remove)
+                return TRUE
 	return FALSE
 
 /*

--- a/code/modules/antagonists/changeling/genetic_matrix_content.dm
+++ b/code/modules/antagonists/changeling/genetic_matrix_content.dm
@@ -18,10 +18,10 @@ GLOBAL_LIST_INIT(changeling_genetic_matrix_recipes, list(
 			"exclusiveTags" = list("key_active"),
 			"button_icon_state" = "dissonant_shriek",
 		),
-		"requiredCells" = list(
-			"/datum/micro_organism/cell_line/vox",
-			"/datum/micro_organism/cell_line/tajaran",
-		),
+                "requiredCells" = list(
+                        CHANGELING_CELL_ID_VOX,
+                        CHANGELING_CELL_ID_TAJARAN,
+                ),
 		"requiredAbilities" = list(
 			/datum/action/changeling/dissonant_shriek,
 		),
@@ -40,10 +40,10 @@ GLOBAL_LIST_INIT(changeling_genetic_matrix_recipes, list(
 			"exclusiveTags" = list("healing"),
 			"button_icon_state" = "regenerate",
 		),
-		"requiredCells" = list(
-			"/datum/micro_organism/cell_line/human",
-			"/datum/micro_organism/cell_line/goat",
-		),
+                "requiredCells" = list(
+                        CHANGELING_CELL_ID_HUMAN,
+                        CHANGELING_CELL_ID_GOAT,
+                ),
 		"requiredAbilities" = list(
 			/datum/action/changeling/regenerate,
 		),
@@ -62,10 +62,10 @@ GLOBAL_LIST_INIT(changeling_genetic_matrix_recipes, list(
 			"exclusiveTags" = list("stealth"),
 			"button_icon_state" = "digital_camo",
 		),
-		"requiredCells" = list(
-			"/datum/micro_organism/cell_line/teshari",
-			"/datum/micro_organism/cell_line/chicken",
-		),
+                "requiredCells" = list(
+                        CHANGELING_CELL_ID_TESHARI,
+                        CHANGELING_CELL_ID_CHICKEN,
+                ),
 		"requiredAbilities" = list(
 			/datum/action/changeling/digitalcamo,
 		),
@@ -84,10 +84,10 @@ GLOBAL_LIST_INIT(changeling_genetic_matrix_recipes, list(
 			"exclusiveTags" = list("mobility"),
 			"button_icon_state" = "strained_muscles",
 		),
-		"requiredCells" = list(
-			"/datum/micro_organism/cell_line/tajaran",
-			"/datum/micro_organism/cell_line/rare_predator",
-		),
+                "requiredCells" = list(
+                        CHANGELING_CELL_ID_TAJARAN,
+                        CHANGELING_CELL_ID_RARE_PREDATOR,
+                ),
 		"requiredAbilities" = list(
 			/datum/action/changeling/strained_muscles,
 		),
@@ -106,10 +106,10 @@ GLOBAL_LIST_INIT(changeling_genetic_matrix_recipes, list(
 			"exclusiveTags" = list("adaptation"),
 			"button_icon_state" = null,
 		),
-		"requiredCells" = list(
-			"/datum/micro_organism/cell_line/vox",
-			"/datum/micro_organism/cell_line/colossus",
-		),
+                "requiredCells" = list(
+                        CHANGELING_CELL_ID_VOX,
+                        CHANGELING_CELL_ID_COLOSSUS,
+                ),
 		"requiredAbilities" = list(
 			/datum/action/changeling/void_adaption,
 		),
@@ -128,10 +128,10 @@ GLOBAL_LIST_INIT(changeling_genetic_matrix_recipes, list(
 			"exclusiveTags" = list("stamina"),
 			"button_icon_state" = "adrenaline",
 		),
-		"requiredCells" = list(
-			"/datum/micro_organism/cell_line/cow",
-			"/datum/micro_organism/cell_line/human",
-		),
+                "requiredCells" = list(
+                        CHANGELING_CELL_ID_COW,
+                        CHANGELING_CELL_ID_HUMAN,
+                ),
 		"requiredAbilities" = list(
 			/datum/action/changeling/adrenaline,
 		),

--- a/code/modules/antagonists/changeling/powers/harvest_cells.dm
+++ b/code/modules/antagonists/changeling/powers/harvest_cells.dm
@@ -1,7 +1,7 @@
 /datum/action/changeling/sting/harvest_cells
-	name = "Harvest Cells"
-	desc = "We silently pierce a victim or sample to obtain cytology-ready cell lines."
-	helptext = "Collects a cytology cell entry from living station species, barnyard animals, or cytology samples without alerting witnesses."
+        name = "Harvest Cells"
+        desc = "We silently pierce a victim to obtain adaptable cell signatures."
+        helptext = "Collects a compatible cell entry from living station species or barnyard animals without alerting witnesses."
 	button_icon_state = "sting_extract"
 	chemical_cost = 10
 	dna_cost = CHANGELING_POWER_INNATE
@@ -115,90 +115,24 @@
 	to_chat(target, span_warning("You feel a fleeting prick beneath your skin."))
 
 /datum/action/changeling/sting/harvest_cells/proc/collect_cell_ids(atom/target)
-	var/list/ids = list()
-	if(!target)
-		return ids
-	if(isliving(target))
-		var/mob/living/living_target = target
-		for(var/cell_id as anything in get_cell_id_from_living(living_target))
-			if(!(cell_id in ids))
-				ids += cell_id
-		return ids
-	if(istype(target, /obj/item/petri_dish))
-		var/obj/item/petri_dish/dish = target
-		if(dish.sample)
-			for(var/cell_id as anything in collect_cells_from_sample(dish.sample))
-				if(!(cell_id in ids))
-					ids += cell_id
-		return ids
-	if(istype(target, /obj/machinery/vatgrower))
-		var/obj/machinery/vatgrower/vat = target
-		if(vat.biological_sample)
-			for(var/cell_id as anything in collect_cells_from_sample(vat.biological_sample))
-				if(!(cell_id in ids))
-					ids += cell_id
-		return ids
-	if(istype(target, /datum/biological_sample))
-		for(var/cell_id as anything in collect_cells_from_sample(target))
-			if(!(cell_id in ids))
-				ids += cell_id
-	return ids
-
-/datum/action/changeling/sting/harvest_cells/proc/collect_cells_from_sample(datum/biological_sample/sample)
-	var/list/ids = list()
-	if(!sample)
-		return ids
-	for(var/datum/micro_organism/microbe as anything in sample.micro_organisms)
-		if(!istype(microbe, /datum/micro_organism/cell_line))
-			continue
-		var/datum/micro_organism/cell_line/cell_line = microbe
-		var/cell_id = "[cell_line.type]"
-		if(!(cell_id in ids))
-			ids += cell_id
-	return ids
+        var/list/ids = list()
+        if(!target)
+                return ids
+        if(isliving(target))
+                var/mob/living/living_target = target
+                for(var/cell_id as anything in get_cell_id_from_living(living_target))
+                        if(!(cell_id in ids))
+                                ids += cell_id
+        return ids
 
 /datum/action/changeling/sting/harvest_cells/proc/get_cell_id_from_living(mob/living/target)
-	var/list/ids = list()
-	if(!target)
-		return ids
-
-	var/cell_line_source = target.cell_line
-	if(cell_line_source)
-		if(istext(cell_line_source))
-			var/list/cell_line_table = GLOB.cell_line_tables?[cell_line_source]
-			if(islist(cell_line_table))
-				for(var/datum/micro_organism/cell_line/cell_type as anything in cell_line_table)
-					var/cell_id = "[cell_type]"
-					if(!(cell_id in ids))
-						ids += cell_id
-		else if(ispath(cell_line_source, /datum/micro_organism/cell_line))
-			var/cell_id = "[cell_line_source]"
-			if(!(cell_id in ids))
-				ids += cell_id
-
-	if(ids.len)
-		return ids
-
-	if(ishuman(target))
-		var/mob/living/carbon/human/human_target = target
-		if(!human_target.has_dna())
-			return ids
-		var/datum/species/species = human_target.dna?.species
-		var/species_cell_line = species?.cell_line
-		if(species_cell_line)
-			if(istext(species_cell_line))
-				var/list/species_cell_line_table = GLOB.cell_line_tables?[species_cell_line]
-				if(islist(species_cell_line_table))
-					for(var/datum/micro_organism/cell_line/cell_type as anything in species_cell_line_table)
-						var/cell_id = "[cell_type]"
-						if(!(cell_id in ids))
-							ids += cell_id
-			else if(ispath(species_cell_line, /datum/micro_organism/cell_line))
-				var/cell_id = "[species_cell_line]"
-				if(!(cell_id in ids))
-					ids += cell_id
-
-	return ids
+        var/list/ids = list()
+        if(!target)
+                return ids
+        for(var/cell_id as anything in changeling_get_cell_ids_from_mob(target))
+                if(!(cell_id in ids))
+                        ids += cell_id
+        return ids
 /datum/action/changeling/sting/harvest_cells/proc/can_use_harvest(mob/living/user)
 	if(!can_be_used_by(user))
 		return FALSE

--- a/code/modules/mob/living/basic/farm_animals/chicken/chicken.dm
+++ b/code/modules/mob/living/basic/farm_animals/chicken/chicken.dm
@@ -32,7 +32,6 @@ GLOBAL_VAR_INIT(chicken_count, 0)
 	pass_flags = PASSTABLE | PASSMOB
 	mob_size = MOB_SIZE_SMALL
 	gold_core_spawnable = FRIENDLY_SPAWN
-	cell_line = CELL_LINE_TABLE_CHICKEN
 
 	ai_controller = /datum/ai_controller/basic_controller/chicken
 
@@ -58,8 +57,7 @@ GLOBAL_VAR_INIT(chicken_count, 0)
 	AddElement(/datum/element/ai_retaliate)
 	AddElement(/datum/element/pet_bonus, "cluck")
 	AddElement(/datum/element/footstep, FOOTSTEP_MOB_CLAW)
-	AddElement(/datum/element/swabable, CELL_LINE_TABLE_CHICKEN, CELL_VIRUS_TABLE_GENERIC_MOB, 1, 5)
-	AddElement(/datum/element/animal_variety, "chicken", pick("brown", "black", "white"), modify_pixels = TRUE)
+        AddElement(/datum/element/animal_variety, "chicken", pick("brown", "black", "white"), modify_pixels = TRUE)
 	AddComponent(\
 		/datum/component/egg_layer,\
 		/obj/item/food/egg/organic,\

--- a/code/modules/mob/living/basic/farm_animals/cow/_cow.dm
+++ b/code/modules/mob/living/basic/farm_animals/cow/_cow.dm
@@ -27,9 +27,8 @@
 	gold_core_spawnable = FRIENDLY_SPAWN
 	blood_volume = BLOOD_VOLUME_NORMAL
 	ai_controller = /datum/ai_controller/basic_controller/cow
-	cell_line = CELL_LINE_TABLE_COW
-	/// what this cow munches on, and what can be used to tame it.
-	var/list/food_types = list(/obj/item/food/grown/wheat)
+        /// what this cow munches on, and what can be used to tame it.
+        var/list/food_types = list(/obj/item/food/grown/wheat)
 	/// message sent when tamed
 	var/tame_message = "lets out a happy moo"
 	/// singular version for player cows
@@ -56,9 +55,8 @@
 		self_right_time = rand(25 SECONDS, 50 SECONDS), \
 		post_tipped_callback = CALLBACK(src, PROC_REF(after_cow_tipped)))
 	AddElement(/datum/element/pet_bonus, "moo")
-	AddElement(/datum/element/swabable, CELL_LINE_TABLE_COW, CELL_VIRUS_TABLE_GENERIC_MOB, 1, 5)
-	setup_udder()
-	setup_eating()
+        setup_udder()
+        setup_eating()
 	. = ..()
 	ai_controller.set_blackboard_key(BB_BASIC_FOODS, typecacheof(food_types))
 

--- a/code/modules/mob/living/basic/farm_animals/goat/_goat.dm
+++ b/code/modules/mob/living/basic/farm_animals/goat/_goat.dm
@@ -34,9 +34,8 @@
 	blood_volume = BLOOD_VOLUME_NORMAL
 
 	ai_controller = /datum/ai_controller/basic_controller/goat
-	cell_line = CELL_LINE_TABLE_GOAT
-	/// How often will we develop an evil gleam in our eye?
-	var/gleam_delay = 20 SECONDS
+        /// How often will we develop an evil gleam in our eye?
+        var/gleam_delay = 20 SECONDS
 	/// Time until we can next gleam evilly
 	COOLDOWN_DECLARE(gleam_cooldown)
 	/// List of stuff (flora) that we want to eat

--- a/code/modules/mob/living/basic/space_fauna/carp/carp.dm
+++ b/code/modules/mob/living/basic/space_fauna/carp/carp.dm
@@ -48,10 +48,8 @@
 
 	/// If true we will run away from attackers even at full health
 	var/cowardly = FALSE
-	/// Cytology cells you can swab from this creature
-	cell_line = CELL_LINE_TABLE_CARP
-	/// What colour is our 'healing' outline?
-	var/regenerate_colour = COLOR_PALE_GREEN
+        /// What colour is our 'healing' outline?
+        var/regenerate_colour = COLOR_PALE_GREEN
 	/// Ability which lets carp teleport around
 	var/datum/action/cooldown/mob_cooldown/lesser_carp_rift/teleport
 	/// Information to apply when treating this carp as a vehicle
@@ -99,9 +97,7 @@
 	apply_colour()
 	add_traits(list(TRAIT_HEALS_FROM_CARP_RIFTS, TRAIT_SPACEWALK), INNATE_TRAIT)
 
-	if (cell_line)
-		AddElement(/datum/element/swabable, cell_line, CELL_VIRUS_TABLE_GENERIC_MOB, 1, 5)
-	AddElement(/datum/element/simple_flying)
+        AddElement(/datum/element/simple_flying)
 	if (!cowardly)
 		AddElement(/datum/element/ai_flee_while_injured)
 	setup_eating()
@@ -179,13 +175,12 @@
  * Holographic carp from the holodeck
  */
 /mob/living/basic/carp/holographic
-	icon_state = "base_friend"
-	icon_living = "holocarp"
-	gold_core_spawnable = NO_SPAWN
-	greyscale_config = NONE
-	basic_mob_flags = DEL_ON_DEATH
-	cell_line = NONE
-	regenerate_colour = "#ffffff"
+        icon_state = "base_friend"
+        icon_living = "holocarp"
+        gold_core_spawnable = NO_SPAWN
+        greyscale_config = NONE
+        basic_mob_flags = DEL_ON_DEATH
+        regenerate_colour = "#ffffff"
 
 /mob/living/basic/carp/holographic/Initialize(mapload, mob/tamer)
 	. = ..()

--- a/code/modules/mob/living/basic/space_fauna/carp/megacarp.dm
+++ b/code/modules/mob/living/basic/space_fauna/carp/megacarp.dm
@@ -20,8 +20,7 @@
 	base_pixel_x = -16
 	mob_size = MOB_SIZE_LARGE
 	obj_damage = 80
-	cell_line = CELL_LINE_TABLE_MEGACARP
-	ridable_data = /datum/component/riding/creature/megacarp
+        ridable_data = /datum/component/riding/creature/megacarp
 	greyscale_config = /datum/greyscale_config/carp_mega
 	butcher_results = list(/obj/item/food/fishmeat/carp = 2, /obj/item/stack/sheet/animalhide/carp = 3)
 	ai_controller = /datum/ai_controller/basic_controller/carp/mega

--- a/code/modules/mob/living/carbon/human/_species.dm
+++ b/code/modules/mob/living/carbon/human/_species.dm
@@ -116,10 +116,8 @@ GLOBAL_LIST_EMPTY(features_by_species)
 	var/stunmod = 1
 	///multiplier for money paid at payday
 	var/payday_modifier = 1.0
-	/// Cytology cell line table identifier supplied when harvesting this species.
-	var/cell_line
-	///Base electrocution coefficient.  Basically a multiplier for damage from electrocutions.
-	var/siemens_coeff = 1
+        ///Base electrocution coefficient.  Basically a multiplier for damage from electrocutions.
+        var/siemens_coeff = 1
 	///To use MUTCOLOR with a fixed color that's independent of the mcolor feature in DNA.
 	var/fixed_mut_color = ""
 	///Special mutation that can be found in the genepool exclusively in this species. Dont leave empty or changing species will be a headache

--- a/code/modules/mob/living/carbon/human/species_types/humans.dm
+++ b/code/modules/mob/living/carbon/human/species_types/humans.dm
@@ -7,7 +7,6 @@
 	skinned_type = /obj/item/stack/sheet/animalhide/human
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT
 	payday_modifier = 1.1
-	cell_line = CELL_LINE_TABLE_HUMAN
 
 /datum/species/human/prepare_human_for_preview(mob/living/carbon/human/human)
 	human.set_haircolor("#bb9966", update = FALSE) // brown

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -108,10 +108,8 @@
 	var/mob_size = MOB_SIZE_HUMAN
 	/// List of biotypes the mob belongs to. Used by diseases and reagents mainly.
 	var/mob_biotypes = MOB_ORGANIC
-	/// Cytology cell line table identifier harvested by bioengineering abilities.
-	var/cell_line
-	/// The type of respiration the mob is capable of doing. Used by adjustOxyLoss.
-	var/mob_respiration_type = RESPIRATION_OXYGEN
+        /// The type of respiration the mob is capable of doing. Used by adjustOxyLoss.
+        var/mob_respiration_type = RESPIRATION_OXYGEN
 	///more or less efficiency to metabolize helpful/harmful reagents and regulate body temperature..
 	var/metabolism_efficiency = 1
 	///does the mob have distinct limbs?(arms,legs, chest,head)

--- a/code/modules/research/xenobiology/vatgrowing/samples/cell_lines/common.dm
+++ b/code/modules/research/xenobiology/vatgrowing/samples/cell_lines/common.dm
@@ -46,60 +46,8 @@
 	virus_suspectibility = 1.5
 	growth_rate = VAT_GROWTH_RATE
 
-/datum/micro_organism/cell_line/vox
-	desc = "Avian-reptilian cell lattice"
-	required_reagents = list(
-		/datum/reagent/consumable/nutriment/protein,
-		/datum/reagent/consumable/nutriment,
-	)
-	supplementary_reagents = list(
-		/datum/reagent/consumable/nutriment/vitamin = 1,
-		/datum/reagent/consumable/liquidgibs = 1,
-		/datum/reagent/growthserum = 2,
-	)
-	suppressive_reagents = list(
-		/datum/reagent/consumable/garlic = -2,
-		/datum/reagent/toxin = -3,
-	)
-	virus_suspectibility = 1.2
-	growth_rate = VAT_GROWTH_RATE
-
-/datum/micro_organism/cell_line/tajaran
-	desc = "Feline humanoid cells"
-	required_reagents = list(
-		/datum/reagent/consumable/nutriment/protein,
-		/datum/reagent/consumable/liquidgibs,
-	)
-	supplementary_reagents = list(
-		/datum/reagent/growthserum = 3,
-		/datum/reagent/consumable/nutriment/vitamin = 2,
-	)
-	suppressive_reagents = list(
-		/datum/reagent/consumable/coco = -2,
-		/datum/reagent/consumable/coffee = -2,
-	)
-	virus_suspectibility = 1.4
-	growth_rate = VAT_GROWTH_RATE
-
-/datum/micro_organism/cell_line/teshari
-	desc = "Feathered theropod cells"
-	required_reagents = list(
-		/datum/reagent/consumable/nutriment/protein,
-	)
-	supplementary_reagents = list(
-		/datum/reagent/growthserum = 3,
-		/datum/reagent/consumable/nutriment/vitamin = 1,
-		/datum/reagent/consumable/eggyolk = 1,
-	)
-	suppressive_reagents = list(
-		/datum/reagent/toxin = -2,
-		/datum/reagent/fuel/oil = -2,
-	)
-	virus_suspectibility = 1.3
-	growth_rate = VAT_GROWTH_RATE
-
 /datum/micro_organism/cell_line/chicken //basic cell line designed as a good source of protein and eggyolk.
-	desc = "Galliform skin cells."
+        desc = "Galliform skin cells."
 	required_reagents = list(
 		/datum/reagent/consumable/nutriment/protein,
 	)
@@ -827,35 +775,5 @@
 	)
 	virus_suspectibility = 0
 	resulting_atom = /mob/living/basic/snail
-
-/datum/micro_organism/cell_line/colossus
-	desc = "Crystalline colossus fragments"
-	required_reagents = list(
-		/datum/reagent/consumable/nutriment/protein,
-	)
-	supplementary_reagents = list(
-		/datum/reagent/growthserum = 1,
-		/datum/reagent/consumable/liquidgibs = 2,
-	)
-	suppressive_reagents = list(
-		/datum/reagent/toxin = -4,
-	)
-	virus_suspectibility = 0.5
-	growth_rate = VAT_GROWTH_RATE
-
-/datum/micro_organism/cell_line/rare_predator
-	desc = "Predatory apex cell cluster"
-	required_reagents = list(
-		/datum/reagent/consumable/nutriment/protein,
-		/datum/reagent/consumable/liquidgibs,
-	)
-	supplementary_reagents = list(
-		/datum/reagent/growthserum = 3,
-	)
-	suppressive_reagents = list(
-		/datum/reagent/consumable/condensedcapsaicin = -3,
-	)
-	virus_suspectibility = 2.5
-	growth_rate = VAT_GROWTH_RATE
 
 #undef VAT_GROWTH_RATE

--- a/modular_nova/modules/better_vox/code/vox_species.dm
+++ b/modular_nova/modules/better_vox/code/vox_species.dm
@@ -20,7 +20,6 @@
 	outfit_important_for_life = /datum/outfit/vox
 	species_language_holder = /datum/language_holder/vox
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT
-	cell_line = CELL_LINE_TABLE_VOX
 
 	// Vox are cold resistant, but also heat sensitive
 	bodytemp_heat_damage_limit = (BODYTEMP_HEAT_DAMAGE_LIMIT - 15) // being cold resistant, should make you heat sensitive actual effect ingame isn't much

--- a/modular_nova/modules/customization/modules/mob/living/carbon/human/species/tajaran.dm
+++ b/modular_nova/modules/customization/modules/mob/living/carbon/human/species/tajaran.dm
@@ -17,7 +17,6 @@
 	species_language_holder = /datum/language_holder/tajaran
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT
 	examine_limb_id = SPECIES_MAMMAL
-	cell_line = CELL_LINE_TABLE_TAJARAN
 	bodypart_overrides = list(
 		BODY_ZONE_HEAD = /obj/item/bodypart/head/mutant,
 		BODY_ZONE_CHEST = /obj/item/bodypart/chest/mutant,

--- a/modular_nova/modules/customization/modules/mob/living/carbon/human/species/vox.dm
+++ b/modular_nova/modules/customization/modules/mob/living/carbon/human/species/vox.dm
@@ -31,7 +31,6 @@
 		BODY_ZONE_L_LEG = /obj/item/bodypart/leg/left/mutant/vox,
 		BODY_ZONE_R_LEG = /obj/item/bodypart/leg/right/mutant/vox,
 	)
-	cell_line = CELL_LINE_TABLE_VOX
 	custom_worn_icons = list(
 		LOADOUT_ITEM_HEAD = VOX_HEAD_ICON,
 		LOADOUT_ITEM_MASK = VOX_MASK_ICON,

--- a/modular_nova/modules/teshari/code/_teshari.dm
+++ b/modular_nova/modules/teshari/code/_teshari.dm
@@ -46,7 +46,6 @@
 		BODY_ZONE_L_LEG = /obj/item/bodypart/leg/left/mutant/teshari,
 		BODY_ZONE_R_LEG = /obj/item/bodypart/leg/right/mutant/teshari,
 	)
-	cell_line = CELL_LINE_TABLE_TESHARI
 
 /datum/species/teshari/get_default_mutant_bodyparts()
 	return list(

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3357,6 +3357,7 @@
 #include "code\modules\antagonists\blob\structures\shield.dm"
 #include "code\modules\antagonists\brainwashing\brainwashing.dm"
 #include "code\modules\antagonists\brother\brother.dm"
+#include "code\modules\antagonists\changeling\cell_registry.dm"
 #include "code\modules\antagonists\changeling\cellular_emporium.dm"
 #include "code\modules\antagonists\changeling\bio_incubator.dm"
 #include "code\modules\antagonists\changeling\genetic_matrix_content.dm"


### PR DESCRIPTION
## Summary
- add a centralized changeling cell registry with helper procs for name and species matching
- rework changeling harvest, bio incubator, and matrix code to use simple registry ids while excising cytology data
- remove genetic matrix DNA profile UI and clean up mob/species cytology hooks now that the registry is authoritative

## Testing
- npm run tgui:lint *(fails: existing lint diagnostics in unrelated assets)*

------
https://chatgpt.com/codex/tasks/task_e_68cefca7aee0832a9685e36522b93269