### PR TITLE
Fix inconsistent indentation in DM files

### DIFF
--- a/code/modules/antagonists/changeling/bio_incubator.dm
+++ b/code/modules/antagonists/changeling/bio_incubator.dm
@@ -12,10 +12,10 @@
 
 /// Stores changeling genetic matrix inventory and build configuration.
 /datum/changeling_bio_incubator
-        /// Owning changeling datum.
-        var/datum/antagonist/changeling/changeling
-        /// Unique identifiers for collected cell signatures.
-        var/list/cell_ids = list()
+	/// Owning changeling datum.
+	var/datum/antagonist/changeling/changeling
+	/// Unique identifiers for collected cell signatures.
+	var/list/cell_ids = list()
 	/// Unique identifiers for known crafting recipes.
 	var/list/recipe_ids = list()
 	/// Assoc list of crafted module definitions indexed by identifier.
@@ -91,11 +91,11 @@
 	return output
 
 /datum/changeling_bio_incubator/proc/prune_assignments()
-        for(var/datum/changeling_bio_incubator/build/build as anything in builds)
-                build.ensure_slot_capacity()
-                for(var/i in 1 to build.module_ids.len)
-                        var/module_id = build.module_ids[i]
-                        if(!module_id)
+	for(var/datum/changeling_bio_incubator/build/build as anything in builds)
+		build.ensure_slot_capacity()
+		for(var/i in 1 to build.module_ids.len)
+			var/module_id = build.module_ids[i]
+			if(!module_id)
 				continue
 			if(!changeling?.has_genetic_matrix_module(module_id))
 				build.module_ids[i] = null
@@ -104,8 +104,8 @@
 				build.module_ids[i] = null
 
 /datum/changeling_bio_incubator/proc/assign_module(datum/changeling_bio_incubator/build/build, module_identifier, slot)
-        if(!build)
-                return FALSE
+	if(!build)
+		return FALSE
 	build.ensure_slot_capacity()
 	if(slot < 1 || slot > get_max_slots())
 		return FALSE
@@ -263,11 +263,11 @@
 	return null
 
 /datum/changeling_bio_incubator/proc/add_cell(cell_identifier)
-        var/cell_id = changeling_normalize_cell_id(cell_identifier)
-        if(isnull(cell_id))
-                return FALSE
-        if(cell_id in cell_ids)
-                return FALSE
+	var/cell_id = changeling_normalize_cell_id(cell_identifier)
+	if(isnull(cell_id))
+		return FALSE
+	if(cell_id in cell_ids)
+		return FALSE
 	cell_ids += cell_id
 	notify_update(BIO_INCUBATOR_UPDATE_CELLS)
 	changeling?.update_genetic_matrix_unlocks()
@@ -291,13 +291,13 @@
 	return output
 
 /datum/changeling_bio_incubator/proc/build_cell_entry(cell_id)
-        var/list/entry = list(
-                "id" = cell_id,
-        )
-        var/list/metadata = changeling_get_cell_metadata(cell_id)
-        entry["name"] = changeling_get_cell_display_name(cell_id)
-        entry["desc"] = metadata?["desc"]
-        return entry
+	var/list/entry = list(
+		"id" = cell_id,
+	)
+	var/list/metadata = changeling_get_cell_metadata(cell_id)
+	entry["name"] = changeling_get_cell_display_name(cell_id)
+	entry["desc"] = metadata?["desc"]
+	return entry
 
 /datum/changeling_bio_incubator/proc/get_nice_name_from_path(path_input)
 	return changeling_get_nice_name_from_path(path_input)
@@ -338,28 +338,28 @@
 
 /// Definition of a single build preset.
 /datum/changeling_bio_incubator/build
-        var/datum/changeling_bio_incubator/bio_incubator
-        var/name = "Matrix Build"
-        var/list/module_ids = list()
+	var/datum/changeling_bio_incubator/bio_incubator
+	var/name = "Matrix Build"
+	var/list/module_ids = list()
 
 /datum/changeling_bio_incubator/build/New(datum/changeling_bio_incubator/bio_incubator)
 	. = ..()
 	src.bio_incubator = bio_incubator
 
 /datum/changeling_bio_incubator/build/Destroy()
-        module_ids = null
-        bio_incubator = null
-        return ..()
+	module_ids = null
+	bio_incubator = null
+	return ..()
 
 /datum/changeling_bio_incubator/build/proc/ensure_slot_capacity()
 	while(module_ids.len < bio_incubator?.get_max_slots())
 		module_ids += null
 
 /datum/changeling_bio_incubator/build/proc/clear_configuration()
-        var/changed = FALSE
-        ensure_slot_capacity()
-        for(var/i in 1 to module_ids.len)
-                if(module_ids[i])
+	var/changed = FALSE
+	ensure_slot_capacity()
+	for(var/i in 1 to module_ids.len)
+		if(module_ids[i])
 			module_ids[i] = null
 			changed = TRUE
 	return changed
@@ -377,12 +377,12 @@
 	return TRUE
 
 /datum/changeling_bio_incubator/build/proc/to_data()
-        var/list/data = list(
-                "id" = REF(src),
-                "name" = name,
-        )
-        ensure_slot_capacity()
-        var/list/module_data = list()
+	var/list/data = list(
+		"id" = REF(src),
+		"name" = name,
+	)
+	ensure_slot_capacity()
+	var/list/module_data = list()
 	for(var/i in 1 to module_ids.len)
 		var/module_id = module_ids[i]
 		if(!module_id)

--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -666,12 +666,12 @@
 		if(!push_out_profile())
 			return
 
-        if(!first_profile)
-                first_profile = new_profile
-                current_profile = first_profile
+	if(!first_profile)
+		first_profile = new_profile
+		current_profile = first_profile
 
-        stored_profiles += new_profile
-        absorbed_count++
+	stored_profiles += new_profile
+	absorbed_count++
 
 /*
  * Create a new profile from the given [profile_target]
@@ -694,10 +694,10 @@
 /datum/antagonist/changeling/proc/remove_profile(mob/living/carbon/human/profile_target, force = FALSE)
 	for(var/datum/changeling_profile/found_profile as anything in stored_profiles)
 		if(profile_target.real_name == found_profile.name)
-                        if(found_profile.protected && !force)
-                                continue
-                        stored_profiles -= found_profile
-                        qdel(found_profile)
+			if(found_profile.protected && !force)
+				continue
+			stored_profiles -= found_profile
+			qdel(found_profile)
 
 /*
  * Removes the highest changeling profile from the list
@@ -712,10 +712,10 @@
 			profile_to_remove = found_profile
 			break
 
-        if(profile_to_remove)
-                stored_profiles -= profile_to_remove
-                qdel(profile_to_remove)
-                return TRUE
+	if(profile_to_remove)
+		stored_profiles -= profile_to_remove
+		qdel(profile_to_remove)
+		return TRUE
 	return FALSE
 
 /*

--- a/code/modules/antagonists/changeling/genetic_matrix.dm
+++ b/code/modules/antagonists/changeling/genetic_matrix.dm
@@ -73,9 +73,9 @@
 	changeling.ensure_genetic_matrix_setup()
 	changeling.update_genetic_matrix_unlocks()
 	changeling.prune_genetic_matrix_assignments()
-        data["builds"] = changeling.get_genetic_matrix_builds_data()
-        data["modules"] = changeling.get_genetic_matrix_module_catalog()
-        data["abilities"] = changeling.get_genetic_matrix_ability_catalog()
+	data["builds"] = changeling.get_genetic_matrix_builds_data()
+	data["modules"] = changeling.get_genetic_matrix_module_catalog()
+	data["abilities"] = changeling.get_genetic_matrix_ability_catalog()
 	data["cells"] = incubator ? incubator.get_cells_data() : list()
 	data["recipes"] = changeling.get_genetic_matrix_recipe_data()
 	data["standardAbilities"] = changeling.get_standard_ability_catalog()
@@ -378,12 +378,12 @@
 
 /// Determine whether the changeling has collected a specific cytology cell identifier.
 /datum/antagonist/changeling/proc/has_cytology_cell(cell_identifier)
-        if(isnull(cell_identifier) || !bio_incubator)
-                return FALSE
-        var/cell_id = changeling_normalize_cell_id(cell_identifier)
-        if(!cell_id)
-                return FALSE
-        return cell_id in bio_incubator.cell_ids
+	if(isnull(cell_identifier) || !bio_incubator)
+		return FALSE
+	var/cell_id = changeling_normalize_cell_id(cell_identifier)
+	if(!cell_id)
+		return FALSE
+	return cell_id in bio_incubator.cell_ids
 
 /// Check if a recipe's requirements are satisfied by our inventory.
 /datum/antagonist/changeling/proc/can_access_genetic_recipe(list/recipe_data)
@@ -430,18 +430,18 @@
 				module_block["tags"] = incubator.sanitize_tag_list(module_block["tags"])
 				module_block["exclusiveTags"] = incubator.sanitize_tag_list(module_block["exclusiveTags"])
 		entry["module"] = module_block
-                var/list/cell_entries = list()
-                var/list/required_cells = recipe["requiredCells"]
-                if(islist(required_cells))
-                        for(var/cell_id in required_cells)
-                                var/text_id = changeling_normalize_cell_id(cell_id)
-                                if(isnull(text_id))
-                                        text_id = incubator ? incubator.sanitize_module_id(cell_id) : "[cell_id]"
-                                cell_entries += list(list(
-                                        "id" = text_id,
-                                        "name" = changeling_get_cell_display_name(cell_id),
-                                        "have" = has_cytology_cell(cell_id),
-                                ))
+		var/list/cell_entries = list()
+		var/list/required_cells = recipe["requiredCells"]
+		if(islist(required_cells))
+			for(var/cell_id in required_cells)
+				var/text_id = changeling_normalize_cell_id(cell_id)
+				if(isnull(text_id))
+					text_id = incubator ? incubator.sanitize_module_id(cell_id) : "[cell_id]"
+				cell_entries += list(list(
+					"id" = text_id,
+					"name" = changeling_get_cell_display_name(cell_id),
+					"have" = has_cytology_cell(cell_id),
+				))
 		entry["requiredCells"] = cell_entries
 		var/list/ability_entries = list()
 		var/list/required_abilities = recipe["requiredAbilities"]

--- a/code/modules/antagonists/changeling/powers/harvest_cells.dm
+++ b/code/modules/antagonists/changeling/powers/harvest_cells.dm
@@ -1,7 +1,7 @@
 /datum/action/changeling/sting/harvest_cells
-        name = "Harvest Cells"
-        desc = "We silently pierce a victim to obtain adaptable cell signatures."
-        helptext = "Collects a compatible cell entry from living station species or barnyard animals without alerting witnesses."
+	name = "Harvest Cells"
+	desc = "We silently pierce a victim to obtain adaptable cell signatures."
+	helptext = "Collects a compatible cell entry from living station species or barnyard animals without alerting witnesses."
 	button_icon_state = "sting_extract"
 	chemical_cost = 10
 	dna_cost = CHANGELING_POWER_INNATE
@@ -115,24 +115,24 @@
 	to_chat(target, span_warning("You feel a fleeting prick beneath your skin."))
 
 /datum/action/changeling/sting/harvest_cells/proc/collect_cell_ids(atom/target)
-        var/list/ids = list()
-        if(!target)
-                return ids
-        if(isliving(target))
-                var/mob/living/living_target = target
-                for(var/cell_id as anything in get_cell_id_from_living(living_target))
-                        if(!(cell_id in ids))
-                                ids += cell_id
-        return ids
+	var/list/ids = list()
+	if(!target)
+		return ids
+	if(isliving(target))
+		var/mob/living/living_target = target
+		for(var/cell_id as anything in get_cell_id_from_living(living_target))
+			if(!(cell_id in ids))
+				ids += cell_id
+	return ids
 
 /datum/action/changeling/sting/harvest_cells/proc/get_cell_id_from_living(mob/living/target)
-        var/list/ids = list()
-        if(!target)
-                return ids
-        for(var/cell_id as anything in changeling_get_cell_ids_from_mob(target))
-                if(!(cell_id in ids))
-                        ids += cell_id
-        return ids
+	var/list/ids = list()
+	if(!target)
+		return ids
+	for(var/cell_id as anything in changeling_get_cell_ids_from_mob(target))
+		if(!(cell_id in ids))
+			ids += cell_id
+	return ids
 /datum/action/changeling/sting/harvest_cells/proc/can_use_harvest(mob/living/user)
 	if(!can_be_used_by(user))
 		return FALSE

--- a/code/modules/mob/living/basic/farm_animals/chicken/chicken.dm
+++ b/code/modules/mob/living/basic/farm_animals/chicken/chicken.dm
@@ -57,7 +57,7 @@ GLOBAL_VAR_INIT(chicken_count, 0)
 	AddElement(/datum/element/ai_retaliate)
 	AddElement(/datum/element/pet_bonus, "cluck")
 	AddElement(/datum/element/footstep, FOOTSTEP_MOB_CLAW)
-        AddElement(/datum/element/animal_variety, "chicken", pick("brown", "black", "white"), modify_pixels = TRUE)
+	AddElement(/datum/element/animal_variety, "chicken", pick("brown", "black", "white"), modify_pixels = TRUE)
 	AddComponent(\
 		/datum/component/egg_layer,\
 		/obj/item/food/egg/organic,\

--- a/code/modules/mob/living/basic/farm_animals/cow/_cow.dm
+++ b/code/modules/mob/living/basic/farm_animals/cow/_cow.dm
@@ -27,8 +27,8 @@
 	gold_core_spawnable = FRIENDLY_SPAWN
 	blood_volume = BLOOD_VOLUME_NORMAL
 	ai_controller = /datum/ai_controller/basic_controller/cow
-        /// what this cow munches on, and what can be used to tame it.
-        var/list/food_types = list(/obj/item/food/grown/wheat)
+	/// what this cow munches on, and what can be used to tame it.
+	var/list/food_types = list(/obj/item/food/grown/wheat)
 	/// message sent when tamed
 	var/tame_message = "lets out a happy moo"
 	/// singular version for player cows
@@ -55,8 +55,8 @@
 		self_right_time = rand(25 SECONDS, 50 SECONDS), \
 		post_tipped_callback = CALLBACK(src, PROC_REF(after_cow_tipped)))
 	AddElement(/datum/element/pet_bonus, "moo")
-        setup_udder()
-        setup_eating()
+	setup_udder()
+	setup_eating()
 	. = ..()
 	ai_controller.set_blackboard_key(BB_BASIC_FOODS, typecacheof(food_types))
 

--- a/code/modules/mob/living/basic/farm_animals/goat/_goat.dm
+++ b/code/modules/mob/living/basic/farm_animals/goat/_goat.dm
@@ -34,8 +34,8 @@
 	blood_volume = BLOOD_VOLUME_NORMAL
 
 	ai_controller = /datum/ai_controller/basic_controller/goat
-        /// How often will we develop an evil gleam in our eye?
-        var/gleam_delay = 20 SECONDS
+	/// How often will we develop an evil gleam in our eye?
+	var/gleam_delay = 20 SECONDS
 	/// Time until we can next gleam evilly
 	COOLDOWN_DECLARE(gleam_cooldown)
 	/// List of stuff (flora) that we want to eat

--- a/code/modules/mob/living/basic/space_fauna/carp/carp.dm
+++ b/code/modules/mob/living/basic/space_fauna/carp/carp.dm
@@ -48,8 +48,8 @@
 
 	/// If true we will run away from attackers even at full health
 	var/cowardly = FALSE
-        /// What colour is our 'healing' outline?
-        var/regenerate_colour = COLOR_PALE_GREEN
+	/// What colour is our 'healing' outline?
+	var/regenerate_colour = COLOR_PALE_GREEN
 	/// Ability which lets carp teleport around
 	var/datum/action/cooldown/mob_cooldown/lesser_carp_rift/teleport
 	/// Information to apply when treating this carp as a vehicle
@@ -97,7 +97,7 @@
 	apply_colour()
 	add_traits(list(TRAIT_HEALS_FROM_CARP_RIFTS, TRAIT_SPACEWALK), INNATE_TRAIT)
 
-        AddElement(/datum/element/simple_flying)
+	AddElement(/datum/element/simple_flying)
 	if (!cowardly)
 		AddElement(/datum/element/ai_flee_while_injured)
 	setup_eating()
@@ -175,12 +175,12 @@
  * Holographic carp from the holodeck
  */
 /mob/living/basic/carp/holographic
-        icon_state = "base_friend"
-        icon_living = "holocarp"
-        gold_core_spawnable = NO_SPAWN
-        greyscale_config = NONE
-        basic_mob_flags = DEL_ON_DEATH
-        regenerate_colour = "#ffffff"
+	icon_state = "base_friend"
+	icon_living = "holocarp"
+	gold_core_spawnable = NO_SPAWN
+	greyscale_config = NONE
+	basic_mob_flags = DEL_ON_DEATH
+	regenerate_colour = "#ffffff"
 
 /mob/living/basic/carp/holographic/Initialize(mapload, mob/tamer)
 	. = ..()

--- a/code/modules/mob/living/basic/space_fauna/carp/megacarp.dm
+++ b/code/modules/mob/living/basic/space_fauna/carp/megacarp.dm
@@ -20,7 +20,7 @@
 	base_pixel_x = -16
 	mob_size = MOB_SIZE_LARGE
 	obj_damage = 80
-        ridable_data = /datum/component/riding/creature/megacarp
+	ridable_data = /datum/component/riding/creature/megacarp
 	greyscale_config = /datum/greyscale_config/carp_mega
 	butcher_results = list(/obj/item/food/fishmeat/carp = 2, /obj/item/stack/sheet/animalhide/carp = 3)
 	ai_controller = /datum/ai_controller/basic_controller/carp/mega

--- a/code/modules/mob/living/carbon/human/_species.dm
+++ b/code/modules/mob/living/carbon/human/_species.dm
@@ -116,8 +116,8 @@ GLOBAL_LIST_EMPTY(features_by_species)
 	var/stunmod = 1
 	///multiplier for money paid at payday
 	var/payday_modifier = 1.0
-        ///Base electrocution coefficient.  Basically a multiplier for damage from electrocutions.
-        var/siemens_coeff = 1
+	///Base electrocution coefficient.  Basically a multiplier for damage from electrocutions.
+	var/siemens_coeff = 1
 	///To use MUTCOLOR with a fixed color that's independent of the mcolor feature in DNA.
 	var/fixed_mut_color = ""
 	///Special mutation that can be found in the genepool exclusively in this species. Dont leave empty or changing species will be a headache

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -108,8 +108,8 @@
 	var/mob_size = MOB_SIZE_HUMAN
 	/// List of biotypes the mob belongs to. Used by diseases and reagents mainly.
 	var/mob_biotypes = MOB_ORGANIC
-        /// The type of respiration the mob is capable of doing. Used by adjustOxyLoss.
-        var/mob_respiration_type = RESPIRATION_OXYGEN
+	/// The type of respiration the mob is capable of doing. Used by adjustOxyLoss.
+	var/mob_respiration_type = RESPIRATION_OXYGEN
 	///more or less efficiency to metabolize helpful/harmful reagents and regulate body temperature..
 	var/metabolism_efficiency = 1
 	///does the mob have distinct limbs?(arms,legs, chest,head)

--- a/code/modules/research/xenobiology/vatgrowing/samples/cell_lines/common.dm
+++ b/code/modules/research/xenobiology/vatgrowing/samples/cell_lines/common.dm
@@ -47,7 +47,7 @@
 	growth_rate = VAT_GROWTH_RATE
 
 /datum/micro_organism/cell_line/chicken //basic cell line designed as a good source of protein and eggyolk.
-        desc = "Galliform skin cells."
+	desc = "Galliform skin cells."
 	required_reagents = list(
 		/datum/reagent/consumable/nutriment/protein,
 	)


### PR DESCRIPTION
## Summary
- replace leading spaces with tabs in changeling DM modules to resolve Dream Maker indentation errors
- standardize indentation across mob and xenobiology DM files to keep compilation consistent

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cf0b1c4d94832ab3637dc4a86845ee