### PR TITLE
Restrict changeling cell harvesting to explicit object types

### DIFF
--- a/code/modules/antagonists/changeling/cell_registry.dm
+++ b/code/modules/antagonists/changeling/cell_registry.dm
@@ -214,10 +214,9 @@ GLOBAL_LIST_INIT(changeling_cell_registry, list(
 	var/list/results = list()
 	if(!target)
 		return results
+	if(!isobj(target))
+		return results
 	var/list/registry = changeling_get_cell_registry()
-	for(var/cell_id as anything in changeling_get_cell_ids_from_name(target.name))
-		if(!(cell_id in results))
-			results += cell_id
 	for(var/cell_id in registry)
 		var/list/entry = registry[cell_id]
 		if(!islist(entry))

--- a/code/modules/antagonists/changeling/powers/harvest_cells.dm
+++ b/code/modules/antagonists/changeling/powers/harvest_cells.dm
@@ -137,6 +137,8 @@
 	var/list/ids = list()
 	if(!target)
 		return ids
+	if(!isobj(target))
+		return ids
 	for(var/cell_id as anything in changeling_get_cell_ids_from_atom(target))
 		if(!(cell_id in ids))
 			ids += cell_id


### PR DESCRIPTION
## Summary
- limit changeling non-living cell harvesting to actual objects so we only match registry type entries
- gate the ability's non-living collection path behind the same object check to avoid spurious matches

## Testing
- not run (DreamMaker/Byond tooling unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68cfc0812950832aaafb4fbfde0b5597