### PR TITLE
Restrict changeling human cells to human DNA

### DIFF
--- a/code/modules/antagonists/changeling/cell_registry.dm
+++ b/code/modules/antagonists/changeling/cell_registry.dm
@@ -440,11 +440,13 @@ GLOBAL_LIST_INIT(changeling_cell_registry, list(
 		var/list/entry = registry[cell_id]
 		if(!islist(entry))
 			continue
+		var/list/entry_species = entry[CHANGELING_CELL_REGISTRY_SPECIES]
+		var/entry_has_species = islist(entry_species) && entry_species.len
 		if(changeling_registry_entry_matches_species(entry, species_id))
 			if(!(cell_id in results))
 				results += cell_id
 			continue
-		if(changeling_registry_entry_matches_type(entry, target))
+		if((!entry_has_species || isnull(species_id)) && changeling_registry_entry_matches_type(entry, target))
 			if(!(cell_id in results))
 				results += cell_id
 			continue


### PR DESCRIPTION
## Summary
- prevent the changeling human cell profile from matching other species just because they inherit the human mob type
- allow type-based matches only when the registry entry lacks a species list or the target species is unknown

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cfe59de214832a87232b4325405729