### PR TITLE
Simplify changeling cell groups

### DIFF
--- a/code/modules/antagonists/changeling/cell_registry.dm
+++ b/code/modules/antagonists/changeling/cell_registry.dm
@@ -1,12 +1,10 @@
 #define CHANGELING_CELL_REGISTRY_NAME "name"
 #define CHANGELING_CELL_REGISTRY_DESC "desc"
-#define CHANGELING_CELL_REGISTRY_KEYWORDS "keywords"
 #define CHANGELING_CELL_REGISTRY_TYPES "types"
 #define CHANGELING_CELL_REGISTRY_SPECIES "species"
 
 #define CHANGELING_CELL_ID_HUMAN "human"
 #define CHANGELING_CELL_ID_LIZARD "lizard"
-#define CHANGELING_CELL_ID_UNATHI "unathi"
 #define CHANGELING_CELL_ID_VOX "vox"
 #define CHANGELING_CELL_ID_TAJARAN "tajaran"
 #define CHANGELING_CELL_ID_TESHARI "teshari"
@@ -19,16 +17,10 @@
 #define CHANGELING_CELL_ID_PLASMAMAN "plasmaman"
 #define CHANGELING_CELL_ID_ETHEREAL "ethereal"
 #define CHANGELING_CELL_ID_SNAIL "snail"
-#define CHANGELING_CELL_ID_MAMMAL "mammal"
-#define CHANGELING_CELL_ID_HUMANOID "humanoid"
 #define CHANGELING_CELL_ID_XENO "xeno"
 #define CHANGELING_CELL_ID_SLIMEPERSON "slimeperson"
 #define CHANGELING_CELL_ID_PODWEAK "podweak"
 #define CHANGELING_CELL_ID_DWARF "dwarf"
-#define CHANGELING_CELL_ID_SYNTH "synth"
-#define CHANGELING_CELL_ID_AQUATIC "aquatic"
-#define CHANGELING_CELL_ID_INSECT "insect"
-#define CHANGELING_CELL_ID_INSECTOID "insectoid"
 #define CHANGELING_CELL_ID_GHOUL "ghoul"
 #define CHANGELING_CELL_ID_HEMOPHAGE "hemophage"
 #define CHANGELING_CELL_ID_ABDUCTORWEAK "abductorweak"
@@ -38,196 +30,129 @@
 #define CHANGELING_CELL_ID_CHICKEN "chicken"
 #define CHANGELING_CELL_ID_COW "cow"
 #define CHANGELING_CELL_ID_GOAT "goat"
-#define CHANGELING_CELL_ID_RARE_PREDATOR "rare_predator"
 #define CHANGELING_CELL_ID_COLOSSUS "colossus"
 
 GLOBAL_LIST_INIT(changeling_cell_registry, list(
         CHANGELING_CELL_ID_HUMAN = list(
                 CHANGELING_CELL_REGISTRY_NAME = "Human Crew",
-                CHANGELING_CELL_REGISTRY_DESC = "Baseline Nanotrasen crew biomatter.",
-                CHANGELING_CELL_REGISTRY_SPECIES = list(SPECIES_HUMAN),
-                CHANGELING_CELL_REGISTRY_KEYWORDS = list("human", "crew"),
+                CHANGELING_CELL_REGISTRY_DESC = "Baseline humanoid biomatter drawn from Nanotrasen-aligned crew.",
+                CHANGELING_CELL_REGISTRY_SPECIES = list(SPECIES_HUMAN, SPECIES_HUMANOID),
                 CHANGELING_CELL_REGISTRY_TYPES = list(/mob/living/carbon/human),
         ),
         CHANGELING_CELL_ID_LIZARD = list(
                 CHANGELING_CELL_REGISTRY_NAME = "Lizard",
-                CHANGELING_CELL_REGISTRY_DESC = "Cold-blooded scales and temperature-bleeding musculature from lizardfolk.",
-                CHANGELING_CELL_REGISTRY_SPECIES = list(SPECIES_LIZARD, SPECIES_LIZARD_ASH, SPECIES_LIZARD_SILVER),
-                CHANGELING_CELL_REGISTRY_KEYWORDS = list("lizard", "ashwalker", "silverscale"),
-        ),
-        CHANGELING_CELL_ID_UNATHI = list(
-                CHANGELING_CELL_REGISTRY_NAME = "Unathi",
-                CHANGELING_CELL_REGISTRY_DESC = "Saurian endocrine mesh and disciplined muscle fiber cultivated from Unathi hunters.",
-                CHANGELING_CELL_REGISTRY_SPECIES = list(SPECIES_UNATHI),
-                CHANGELING_CELL_REGISTRY_KEYWORDS = list("unathi"),
+                CHANGELING_CELL_REGISTRY_DESC = "Cold-blooded scales and disciplined musculature harvested from lizardfolk and Unathi hunters.",
+                CHANGELING_CELL_REGISTRY_SPECIES = list(SPECIES_LIZARD, SPECIES_LIZARD_ASH, SPECIES_LIZARD_SILVER, SPECIES_UNATHI),
         ),
         CHANGELING_CELL_ID_VOX = list(
                 CHANGELING_CELL_REGISTRY_NAME = "Vox",
                 CHANGELING_CELL_REGISTRY_DESC = "Avian cortical cluster harvested from Vox biology.",
                 CHANGELING_CELL_REGISTRY_SPECIES = list(SPECIES_VOX, SPECIES_VOX_PRIMALIS),
-                CHANGELING_CELL_REGISTRY_KEYWORDS = list("vox"),
         ),
         CHANGELING_CELL_ID_TAJARAN = list(
                 CHANGELING_CELL_REGISTRY_NAME = "Tajaran",
                 CHANGELING_CELL_REGISTRY_DESC = "Feline survival tissues gleaned from Tajaran hosts.",
                 CHANGELING_CELL_REGISTRY_SPECIES = list(SPECIES_TAJARAN),
-                CHANGELING_CELL_REGISTRY_KEYWORDS = list("tajaran"),
         ),
         CHANGELING_CELL_ID_TESHARI = list(
                 CHANGELING_CELL_REGISTRY_NAME = "Teshari",
                 CHANGELING_CELL_REGISTRY_DESC = "Lightweight musculature adapted for Teshari sprinters.",
                 CHANGELING_CELL_REGISTRY_SPECIES = list(SPECIES_TESHARI),
-                CHANGELING_CELL_REGISTRY_KEYWORDS = list("teshari"),
         ),
         CHANGELING_CELL_ID_FELINID = list(
                 CHANGELING_CELL_REGISTRY_NAME = "Felinid",
                 CHANGELING_CELL_REGISTRY_DESC = "Feline balance organs and quick-twitch tendons from agile felinids.",
                 CHANGELING_CELL_REGISTRY_SPECIES = list(SPECIES_FELINE, SPECIES_FELINE_PRIMITIVE),
-                CHANGELING_CELL_REGISTRY_KEYWORDS = list("felinid", "cat"),
         ),
         CHANGELING_CELL_ID_VULPKANIN = list(
                 CHANGELING_CELL_REGISTRY_NAME = "Vulpkanin",
                 CHANGELING_CELL_REGISTRY_DESC = "Canid olfactory bundles and endurance-ready musculature from vulpkanin scouts.",
                 CHANGELING_CELL_REGISTRY_SPECIES = list(SPECIES_VULP),
-                CHANGELING_CELL_REGISTRY_KEYWORDS = list("vulpkanin", "fox"),
         ),
         CHANGELING_CELL_ID_AKULA = list(
                 CHANGELING_CELL_REGISTRY_NAME = "Akula",
                 CHANGELING_CELL_REGISTRY_DESC = "Hydrodynamic cartilage and saline-adapted musculature drawn from akula swimmers.",
                 CHANGELING_CELL_REGISTRY_SPECIES = list(SPECIES_AKULA),
-                CHANGELING_CELL_REGISTRY_KEYWORDS = list("akula", "shark"),
         ),
         CHANGELING_CELL_ID_SKRELL = list(
                 CHANGELING_CELL_REGISTRY_NAME = "Skrell",
                 CHANGELING_CELL_REGISTRY_DESC = "Neural conduction gel and amphibious cartilage sourced from psionic skrell.",
                 CHANGELING_CELL_REGISTRY_SPECIES = list(SPECIES_SKRELL),
-                CHANGELING_CELL_REGISTRY_KEYWORDS = list("skrell"),
         ),
         CHANGELING_CELL_ID_FLY = list(
                 CHANGELING_CELL_REGISTRY_NAME = "Flyperson",
-                CHANGELING_CELL_REGISTRY_DESC = "Proboscis musculature and hyperactive enzymes salvaged from hardy flypeople.",
-                CHANGELING_CELL_REGISTRY_SPECIES = list(SPECIES_FLYPERSON),
-                CHANGELING_CELL_REGISTRY_KEYWORDS = list("fly", "flyperson"),
+                CHANGELING_CELL_REGISTRY_DESC = "Proboscis musculature and hyperactive enzymes salvaged from flypeople and towering insectoids.",
+                CHANGELING_CELL_REGISTRY_SPECIES = list(SPECIES_FLYPERSON, SPECIES_INSECT, SPECIES_INSECTOID),
         ),
         CHANGELING_CELL_ID_MOTH = list(
                 CHANGELING_CELL_REGISTRY_NAME = "Moth",
                 CHANGELING_CELL_REGISTRY_DESC = "Powdered wing fibers and luminescent chitin drawn from mothkind.",
                 CHANGELING_CELL_REGISTRY_SPECIES = list(SPECIES_MOTH),
-                CHANGELING_CELL_REGISTRY_KEYWORDS = list("moth", "mothman"),
         ),
         CHANGELING_CELL_ID_PLASMAMAN = list(
                 CHANGELING_CELL_REGISTRY_NAME = "Plasmaman",
                 CHANGELING_CELL_REGISTRY_DESC = "Encapsulated plasma membranes stabilized for plasmaman containment.",
                 CHANGELING_CELL_REGISTRY_SPECIES = list(SPECIES_PLASMAMAN),
-                CHANGELING_CELL_REGISTRY_KEYWORDS = list("plasmaman", "plasma"),
         ),
         CHANGELING_CELL_ID_ETHEREAL = list(
                 CHANGELING_CELL_REGISTRY_NAME = "Ethereal",
                 CHANGELING_CELL_REGISTRY_DESC = "Ion-charged lattice and conductive nerve threads harvested from ethereals.",
                 CHANGELING_CELL_REGISTRY_SPECIES = list(SPECIES_ETHEREAL, SPECIES_ETHEREAL_LUSTROUS),
-                CHANGELING_CELL_REGISTRY_KEYWORDS = list("ethereal", "luminescent"),
         ),
         CHANGELING_CELL_ID_SNAIL = list(
                 CHANGELING_CELL_REGISTRY_NAME = "Snail",
                 CHANGELING_CELL_REGISTRY_DESC = "Viscous regenerative tissue and calcified shell plates from gastropoid citizens.",
                 CHANGELING_CELL_REGISTRY_SPECIES = list(SPECIES_SNAIL),
-                CHANGELING_CELL_REGISTRY_KEYWORDS = list("snail"),
-        ),
-        CHANGELING_CELL_ID_MAMMAL = list(
-                CHANGELING_CELL_REGISTRY_NAME = "Mammal",
-                CHANGELING_CELL_REGISTRY_DESC = "Baseline mammalian muscle weave and insulating follicle templates.",
-                CHANGELING_CELL_REGISTRY_SPECIES = list(SPECIES_MAMMAL),
-                CHANGELING_CELL_REGISTRY_KEYWORDS = list("mammal"),
-        ),
-        CHANGELING_CELL_ID_HUMANOID = list(
-                CHANGELING_CELL_REGISTRY_NAME = "Humanoid",
-                CHANGELING_CELL_REGISTRY_DESC = "Generalist humanoid genome optimized for cross-compatible grafting.",
-                CHANGELING_CELL_REGISTRY_SPECIES = list(SPECIES_HUMANOID),
-                CHANGELING_CELL_REGISTRY_KEYWORDS = list("humanoid"),
         ),
         CHANGELING_CELL_ID_XENO = list(
                 CHANGELING_CELL_REGISTRY_NAME = "Xeno-Hybrid",
                 CHANGELING_CELL_REGISTRY_DESC = "Acid-hardened sinew and adaptive chitin taken from xenobiological hybrids.",
                 CHANGELING_CELL_REGISTRY_SPECIES = list(SPECIES_XENO),
-                CHANGELING_CELL_REGISTRY_KEYWORDS = list("xeno"),
         ),
         CHANGELING_CELL_ID_SLIMEPERSON = list(
                 CHANGELING_CELL_REGISTRY_NAME = "Slimeperson",
                 CHANGELING_CELL_REGISTRY_DESC = "Morphogenic cytoplasm and plasmid memory nodes siphoned from slime-derived crew.",
                 CHANGELING_CELL_REGISTRY_SPECIES = list(SPECIES_SLIMESTART, SPECIES_SLIMEPERSON),
-                CHANGELING_CELL_REGISTRY_KEYWORDS = list("slime", "slimeperson"),
         ),
         CHANGELING_CELL_ID_PODWEAK = list(
                 CHANGELING_CELL_REGISTRY_NAME = "Podperson",
                 CHANGELING_CELL_REGISTRY_DESC = "Photosynthetic tendrils and plant-fiber musculature grown within pod sprouts.",
                 CHANGELING_CELL_REGISTRY_SPECIES = list(SPECIES_PODPERSON_WEAK, SPECIES_PODPERSON),
-                CHANGELING_CELL_REGISTRY_KEYWORDS = list("podperson", "pod"),
         ),
         CHANGELING_CELL_ID_DWARF = list(
                 CHANGELING_CELL_REGISTRY_NAME = "Dwarf",
                 CHANGELING_CELL_REGISTRY_DESC = "Dense myofibrils and compact bone lattice recycled from dwarven miners.",
                 CHANGELING_CELL_REGISTRY_SPECIES = list(SPECIES_DWARF),
-                CHANGELING_CELL_REGISTRY_KEYWORDS = list("dwarf"),
-        ),
-        CHANGELING_CELL_ID_SYNTH = list(
-                CHANGELING_CELL_REGISTRY_NAME = "Synth",
-                CHANGELING_CELL_REGISTRY_DESC = "Synthetic myomer bundles and polymer nerve sheaths refined from station synths.",
-                CHANGELING_CELL_REGISTRY_SPECIES = list(SPECIES_SYNTH, SPECIES_ANDROID),
-                CHANGELING_CELL_REGISTRY_KEYWORDS = list("synth", "android"),
-        ),
-        CHANGELING_CELL_ID_AQUATIC = list(
-                CHANGELING_CELL_REGISTRY_NAME = "Aquatic",
-                CHANGELING_CELL_REGISTRY_DESC = "Pressure-tempered tissues and gill matrices taken from aquatic specialists.",
-                CHANGELING_CELL_REGISTRY_SPECIES = list(SPECIES_AQUATIC),
-                CHANGELING_CELL_REGISTRY_KEYWORDS = list("aquatic"),
-        ),
-        CHANGELING_CELL_ID_INSECT = list(
-                CHANGELING_CELL_REGISTRY_NAME = "Insect",
-                CHANGELING_CELL_REGISTRY_DESC = "Segmented exoskeleton plating and rapid chitin regrowth of insect-folk.",
-                CHANGELING_CELL_REGISTRY_SPECIES = list(SPECIES_INSECT),
-                CHANGELING_CELL_REGISTRY_KEYWORDS = list("insect"),
-        ),
-        CHANGELING_CELL_ID_INSECTOID = list(
-                CHANGELING_CELL_REGISTRY_NAME = "Insectoid",
-                CHANGELING_CELL_REGISTRY_DESC = "Hive-born chitin composites and pheromone glands from towering insectoids.",
-                CHANGELING_CELL_REGISTRY_SPECIES = list(SPECIES_INSECTOID),
-                CHANGELING_CELL_REGISTRY_KEYWORDS = list("insectoid"),
         ),
         CHANGELING_CELL_ID_GHOUL = list(
                 CHANGELING_CELL_REGISTRY_NAME = "Ghoul",
                 CHANGELING_CELL_REGISTRY_DESC = "Radiation-stabilized marrow and regenerative necrotic tissue from ghoulish survivors.",
                 CHANGELING_CELL_REGISTRY_SPECIES = list(SPECIES_GHOUL),
-                CHANGELING_CELL_REGISTRY_KEYWORDS = list("ghoul"),
         ),
         CHANGELING_CELL_ID_HEMOPHAGE = list(
                 CHANGELING_CELL_REGISTRY_NAME = "Hemophage",
                 CHANGELING_CELL_REGISTRY_DESC = "Hemovore assimilation glands and blood-filtering sacs cultivated from hemophages.",
                 CHANGELING_CELL_REGISTRY_SPECIES = list(SPECIES_HEMOPHAGE),
-                CHANGELING_CELL_REGISTRY_KEYWORDS = list("hemophage", "blood"),
         ),
         CHANGELING_CELL_ID_ABDUCTORWEAK = list(
                 CHANGELING_CELL_REGISTRY_NAME = "Abductor",
                 CHANGELING_CELL_REGISTRY_DESC = "Altered nervous netting and psionic resonators appropriated from abductors.",
                 CHANGELING_CELL_REGISTRY_SPECIES = list(SPECIES_ABDUCTORWEAK, SPECIES_ABDUCTOR),
-                CHANGELING_CELL_REGISTRY_KEYWORDS = list("abductor"),
         ),
         CHANGELING_CELL_ID_KOBOLD = list(
                 CHANGELING_CELL_REGISTRY_NAME = "Kobold",
                 CHANGELING_CELL_REGISTRY_DESC = "Burrowing tendons and pack-adaptive senses from industrious kobolds.",
                 CHANGELING_CELL_REGISTRY_SPECIES = list(SPECIES_KOBOLD),
-                CHANGELING_CELL_REGISTRY_KEYWORDS = list("kobold"),
         ),
         CHANGELING_CELL_ID_NABBER = list(
                 CHANGELING_CELL_REGISTRY_NAME = "Nabber",
                 CHANGELING_CELL_REGISTRY_DESC = "Elastic spine cords and abyssal chromatophores from predatory nabbers.",
                 CHANGELING_CELL_REGISTRY_SPECIES = list(SPECIES_NABBER),
-                CHANGELING_CELL_REGISTRY_KEYWORDS = list("nabber"),
         ),
         CHANGELING_CELL_ID_SHADEKIN = list(
                 CHANGELING_CELL_REGISTRY_NAME = "Shadekin",
                 CHANGELING_CELL_REGISTRY_DESC = "Shadow-aligned mycelia and reflexive photokinesis nodes gathered from shadekin.",
                 CHANGELING_CELL_REGISTRY_SPECIES = list(SPECIES_SHADEKIN),
-                CHANGELING_CELL_REGISTRY_KEYWORDS = list("shadekin", "shade"),
         ),
         CHANGELING_CELL_ID_CHICKEN = list(
                 CHANGELING_CELL_REGISTRY_NAME = "Chicken",
@@ -239,7 +164,6 @@ GLOBAL_LIST_INIT(changeling_cell_registry, list(
                         /obj/item/food/meat/cutlet/chicken,
                         /obj/item/food/meat/steak/chicken,
                 ),
-                CHANGELING_CELL_REGISTRY_KEYWORDS = list("chicken", "hen"),
         ),
         CHANGELING_CELL_ID_COW = list(
                 CHANGELING_CELL_REGISTRY_NAME = "Cow",
@@ -248,29 +172,16 @@ GLOBAL_LIST_INIT(changeling_cell_registry, list(
                         /mob/living/basic/cow,
                         /obj/item/food/meat/slab/grassfed,
                 ),
-                CHANGELING_CELL_REGISTRY_KEYWORDS = list("cow", "cattle", "grassfed", "eco"),
         ),
         CHANGELING_CELL_ID_GOAT = list(
                 CHANGELING_CELL_REGISTRY_NAME = "Goat",
                 CHANGELING_CELL_REGISTRY_DESC = "Stubborn grazer tissues ideal for endurance grafts.",
                 CHANGELING_CELL_REGISTRY_TYPES = list(/mob/living/basic/goat),
-                CHANGELING_CELL_REGISTRY_KEYWORDS = list("goat"),
-        ),
-        CHANGELING_CELL_ID_RARE_PREDATOR = list(
-                CHANGELING_CELL_REGISTRY_NAME = "Apex Predator",
-                CHANGELING_CELL_REGISTRY_DESC = "Hyperdense combat fibers from rare predators.",
-                CHANGELING_CELL_REGISTRY_TYPES = list(
-                        /mob/living/basic/carp,
-                        /mob/living/basic/carp/mega,
-                        /mob/living/simple_animal/hostile/megafauna,
-                ),
-                CHANGELING_CELL_REGISTRY_KEYWORDS = list("predator", "megafauna", "carp", "dragon", "goliath"),
         ),
         CHANGELING_CELL_ID_COLOSSUS = list(
                 CHANGELING_CELL_REGISTRY_NAME = "Colossus",
                 CHANGELING_CELL_REGISTRY_DESC = "Crystalline lattice fragments from a lavaland colossus.",
                 CHANGELING_CELL_REGISTRY_TYPES = list(/mob/living/simple_animal/hostile/megafauna/colossus),
-                CHANGELING_CELL_REGISTRY_KEYWORDS = list("colossus"),
         ),
 ))
 
@@ -327,14 +238,6 @@ GLOBAL_LIST_INIT(changeling_cell_registry, list(
 	var/entry_name = changeling_normalize_match_text(entry[CHANGELING_CELL_REGISTRY_NAME])
 	if(length(entry_name) && findtext(normalized_name, entry_name))
 		return TRUE
-	var/list/keywords = entry[CHANGELING_CELL_REGISTRY_KEYWORDS]
-	if(islist(keywords))
-		for(var/keyword in keywords)
-			var/normalized_keyword = changeling_normalize_match_text(keyword)
-			if(!length(normalized_keyword))
-				continue
-			if(findtext(normalized_name, normalized_keyword))
-				return TRUE
 	return FALSE
 
 /proc/changeling_registry_entry_matches_species(list/entry, species_id)


### PR DESCRIPTION
## Summary
- merge human/humanoid, lizard/unathi, and fly/insect/insectoid species into shared changeling cell entries
- remove generic mammal, aquatic, synth, and apex predator cell records from the registry
- drop keyword-based matching so cell lookup relies on species, types, and explicit names

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cfec886714832abb969844c485bef4