### PR TITLE
Revise changeling genetic matrix workflow

### DIFF
--- a/code/modules/antagonists/changeling/bio_incubator.dm
+++ b/code/modules/antagonists/changeling/bio_incubator.dm
@@ -12,29 +12,33 @@
 
 /// Stores changeling genetic matrix inventory and build configuration.
 /datum/changeling_bio_incubator
-	/// Owning changeling datum.
-	var/datum/antagonist/changeling/changeling
-	/// Unique identifiers for collected cell signatures.
-	var/list/cell_ids = list()
-	/// Unique identifiers for known crafting recipes.
-	var/list/recipe_ids = list()
-	/// Assoc list of crafted module definitions indexed by identifier.
-	var/list/crafted_modules = list()
-	/// Stored build presets.
-	var/list/datum/changeling_bio_incubator/build/builds = list()
+        /// Owning changeling datum.
+        var/datum/antagonist/changeling/changeling
+        /// Unique identifiers for collected cell signatures.
+        var/list/cell_ids = list()
+        /// Unique identifiers for known crafting recipes.
+        var/list/recipe_ids = list()
+        /// Assoc list of crafted module definitions indexed by identifier.
+        var/list/crafted_modules = list()
+        /// Stored build presets.
+        var/list/datum/changeling_bio_incubator/build/builds = list()
+        /// Currently applied module identifiers indexed by slot.
+        var/list/active_module_ids = list()
 
 /datum/changeling_bio_incubator/New(datum/antagonist/changeling/changeling)
-	. = ..()
-	src.changeling = changeling
+        . = ..()
+        src.changeling = changeling
+        ensure_active_capacity()
 
 /datum/changeling_bio_incubator/Destroy()
-	cell_ids = null
-	recipe_ids = null
-	crafted_modules = null
-	QDEL_LIST(builds)
-	builds = null
-	changeling = null
-	return ..()
+        cell_ids = null
+        recipe_ids = null
+        crafted_modules = null
+        QDEL_LIST(builds)
+        builds = null
+        active_module_ids = null
+        changeling = null
+        return ..()
 
 /datum/changeling_bio_incubator/proc/get_max_builds()
 	return BIO_INCUBATOR_MAX_BUILDS
@@ -46,20 +50,41 @@
 	return builds.len < get_max_builds()
 
 /datum/changeling_bio_incubator/proc/ensure_default_build()
-	if(builds.len)
-		return
-	var/index = builds.len + 1
-	add_build("Matrix Build [index]")
+        var/changed = FALSE
+        if(builds.len > 1)
+                for(var/i in 2 to builds.len)
+                        var/datum/changeling_bio_incubator/build/extra = builds[i]
+                        if(!extra)
+                                continue
+                        qdel(extra)
+                builds.Cut(2, builds.len + 1)
+                changed = TRUE
+        if(!builds.len)
+                var/datum/changeling_bio_incubator/build/build = new(src)
+                build.name = "Genetic Matrix"
+                build.ensure_slot_capacity()
+                builds += list(build)
+                changed = TRUE
+        var/datum/changeling_bio_incubator/build/primary = builds[1]
+        if(primary)
+                primary.ensure_slot_capacity()
+        ensure_active_capacity()
+        if(!active_module_ids.len)
+                apply_build_configuration(primary, notify = FALSE)
+        else
+                sanitize_active_modules()
+        if(changed)
+                notify_update(BIO_INCUBATOR_UPDATE_BUILDS)
 
 /datum/changeling_bio_incubator/proc/add_build(name)
-	if(!can_add_build())
-		return null
-	var/datum/changeling_bio_incubator/build/build = new(src)
-	build.name = name
-	build.ensure_slot_capacity()
-	builds += list(build)
-	notify_update(BIO_INCUBATOR_UPDATE_BUILDS)
-	return build
+        if(!can_add_build())
+                return null
+        var/datum/changeling_bio_incubator/build/build = new(src)
+        build.name = name
+        build.ensure_slot_capacity()
+        builds += list(build)
+        notify_update(BIO_INCUBATOR_UPDATE_BUILDS)
+        return build
 
 /datum/changeling_bio_incubator/proc/remove_build(datum/changeling_bio_incubator/build/build)
 	if(!build)
@@ -85,28 +110,29 @@
 	return null
 
 /datum/changeling_bio_incubator/proc/get_builds_data()
-	var/list/output = list()
-	for(var/datum/changeling_bio_incubator/build/build as anything in builds)
-		output += list(build.to_data())
-	return output
+        var/list/output = list()
+        for(var/datum/changeling_bio_incubator/build/build as anything in builds)
+                output += list(build.to_data())
+        return output
 
 /datum/changeling_bio_incubator/proc/prune_assignments()
-	for(var/datum/changeling_bio_incubator/build/build as anything in builds)
-		build.ensure_slot_capacity()
-		for(var/i in 1 to build.module_ids.len)
+        for(var/datum/changeling_bio_incubator/build/build as anything in builds)
+                build.ensure_slot_capacity()
+                for(var/i in 1 to build.module_ids.len)
 			var/module_id = build.module_ids[i]
 			if(!module_id)
 				continue
-			if(!changeling?.has_genetic_matrix_module(module_id))
-				build.module_ids[i] = null
-				continue
-			if(!module_slot_allowed(module_id, i))
-				build.module_ids[i] = null
+                        if(!changeling?.has_genetic_matrix_module(module_id))
+                                build.module_ids[i] = null
+                                continue
+                        if(!module_slot_allowed(module_id, i))
+                                build.module_ids[i] = null
+        sanitize_active_modules()
 
 /datum/changeling_bio_incubator/proc/assign_module(datum/changeling_bio_incubator/build/build, module_identifier, slot)
-	if(!build)
-		return FALSE
-	build.ensure_slot_capacity()
+        if(!build)
+                return FALSE
+        build.ensure_slot_capacity()
 	if(slot < 1 || slot > get_max_slots())
 		return FALSE
 	if(isnull(module_identifier))
@@ -228,17 +254,26 @@
 	data_copy["exclusiveTags"] = sanitize_tag_list(data_copy["exclusiveTags"])
 	if(!data_copy["source"])
 		data_copy["source"] = "crafted"
-	crafted_modules[module_id] = data_copy
-	notify_update(BIO_INCUBATOR_UPDATE_MODULES)
-	return TRUE
+        crafted_modules[module_id] = data_copy
+        notify_update(BIO_INCUBATOR_UPDATE_MODULES)
+        return TRUE
 
 /datum/changeling_bio_incubator/proc/unregister_module(module_id)
-	module_id = sanitize_module_id(module_id)
-	if(!crafted_modules[module_id])
-		return FALSE
-	del crafted_modules[module_id]
-	notify_update(BIO_INCUBATOR_UPDATE_MODULES | BIO_INCUBATOR_UPDATE_BUILDS)
-	return TRUE
+        module_id = sanitize_module_id(module_id)
+        if(!crafted_modules[module_id])
+                return FALSE
+        del crafted_modules[module_id]
+        ensure_active_capacity()
+        var/changed = FALSE
+        for(var/i in 1 to active_module_ids.len)
+                if(active_module_ids[i] != module_id)
+                        continue
+                active_module_ids[i] = null
+                changed = TRUE
+        if(changed)
+                notify_update(BIO_INCUBATOR_UPDATE_BUILDS)
+        notify_update(BIO_INCUBATOR_UPDATE_MODULES | BIO_INCUBATOR_UPDATE_BUILDS)
+        return TRUE
 
 /datum/changeling_bio_incubator/proc/has_module(module_id)
 	module_id = sanitize_module_id(module_id)
@@ -254,13 +289,86 @@
 	return catalog
 
 /datum/changeling_bio_incubator/proc/get_module_data(module_id)
-	module_id = sanitize_module_id(module_id)
-	if(isnull(module_id))
-		return null
-	var/list/entry = crafted_modules[module_id]
-	if(islist(entry))
-		return entry.Copy()
-	return null
+        module_id = sanitize_module_id(module_id)
+        if(isnull(module_id))
+                return null
+        var/list/entry = crafted_modules[module_id]
+        if(islist(entry))
+                return entry.Copy()
+        return null
+
+/datum/changeling_bio_incubator/proc/ensure_active_capacity()
+        var/max_slots = get_max_slots()
+        if(!islist(active_module_ids))
+                active_module_ids = list()
+        if(max_slots <= 0)
+                active_module_ids.Cut()
+                return
+        while(active_module_ids.len < max_slots)
+                active_module_ids += null
+        if(active_module_ids.len > max_slots)
+                active_module_ids.Cut(max_slots + 1, active_module_ids.len + 1)
+
+/datum/changeling_bio_incubator/proc/get_active_module_ids()
+        ensure_active_capacity()
+        return active_module_ids.Copy()
+
+/datum/changeling_bio_incubator/proc/is_module_active(module_identifier)
+        if(isnull(module_identifier))
+                return FALSE
+        ensure_active_capacity()
+        var/id_text = sanitize_module_id(module_identifier)
+        if(!id_text)
+                return FALSE
+        for(var/module_id in active_module_ids)
+                if(module_id != id_text)
+                        continue
+                return TRUE
+        return FALSE
+
+/datum/changeling_bio_incubator/proc/apply_build_configuration(datum/changeling_bio_incubator/build/build, notify = TRUE)
+        if(!build)
+                return FALSE
+        ensure_active_capacity()
+        build.ensure_slot_capacity()
+        var/max_slots = get_max_slots()
+        var/list/new_active = list()
+        for(var/i in 1 to max_slots)
+                var/module_id = null
+                if(i <= build.module_ids.len)
+                        module_id = sanitize_module_id(build.module_ids[i])
+                if(module_id && (!has_module(module_id) || !module_slot_allowed(module_id, i)))
+                        module_id = null
+                new_active += module_id
+        var/changed = FALSE
+        if(active_module_ids.len != new_active.len)
+                changed = TRUE
+        else
+                for(var/i in 1 to new_active.len)
+                        if(active_module_ids[i] == new_active[i])
+                                continue
+                        changed = TRUE
+                        break
+        active_module_ids = new_active
+        if(changed && notify)
+                notify_update(BIO_INCUBATOR_UPDATE_BUILDS)
+        else if(!changed)
+                ensure_active_capacity()
+        return TRUE
+
+/datum/changeling_bio_incubator/proc/sanitize_active_modules()
+        ensure_active_capacity()
+        var/changed = FALSE
+        for(var/i in 1 to active_module_ids.len)
+                var/module_id = active_module_ids[i]
+                if(!module_id)
+                        continue
+                if(!has_module(module_id) || !module_slot_allowed(module_id, i))
+                        active_module_ids[i] = null
+                        changed = TRUE
+        if(changed)
+                notify_update(BIO_INCUBATOR_UPDATE_BUILDS)
+        return changed
 
 /datum/changeling_bio_incubator/proc/add_cell(cell_identifier)
 	var/cell_id = changeling_normalize_cell_id(cell_identifier)
@@ -377,27 +485,30 @@
 	return TRUE
 
 /datum/changeling_bio_incubator/build/proc/to_data()
-	var/list/data = list(
-		"id" = REF(src),
-		"name" = name,
-	)
-	ensure_slot_capacity()
-	var/list/module_data = list()
-	for(var/i in 1 to module_ids.len)
-		var/module_id = module_ids[i]
-		if(!module_id)
-			module_data += list(null)
-			continue
-		var/list/entry = bio_incubator?.get_module_data(module_id)
-		if(!entry)
-			module_ids[i] = null
-			module_data += list(null)
-			continue
-		entry = entry.Copy()
-		entry["slot"] = i
-		module_data += list(entry)
-	data["modules"] = module_data
-	return data
+        var/list/data = list(
+                "id" = REF(src),
+                "name" = name,
+        )
+        ensure_slot_capacity()
+        var/list/active_ids = bio_incubator?.get_active_module_ids() || list()
+        data["activeModuleIds"] = active_ids.Copy()
+        var/list/module_data = list()
+        for(var/i in 1 to module_ids.len)
+                var/module_id = module_ids[i]
+                if(!module_id)
+                        module_data += list(null)
+                        continue
+                var/list/entry = bio_incubator?.get_module_data(module_id)
+                if(!entry)
+                        module_ids[i] = null
+                        module_data += list(null)
+                        continue
+                entry = entry.Copy()
+                entry["slot"] = i
+                entry["active"] = (i <= active_ids.len) && active_ids[i] == module_id
+                module_data += list(entry)
+        data["modules"] = module_data
+        return data
 
 #undef BIO_INCUBATOR_MAX_MODULE_SLOTS
 #undef BIO_INCUBATOR_MAX_BUILDS

--- a/code/modules/antagonists/changeling/genetic_matrix.dm
+++ b/code/modules/antagonists/changeling/genetic_matrix.dm
@@ -82,9 +82,9 @@
 	data["geneticPoints"] = changeling.genetic_points
 	data["absorbs"] = changeling.true_absorbs
 	data["dnaSamples"] = changeling.absorbed_count
-	data["canReadapt"] = changeling.can_respec
-	data["canAddBuild"] = incubator ? incubator.can_add_build() : FALSE
-	return data
+        data["canReadapt"] = changeling.can_respec
+        data["isReconfiguring"] = changeling.is_genetic_matrix_reconfiguring()
+        return data
 
 /datum/genetic_matrix/ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)
 	. = ..()
@@ -95,44 +95,11 @@
 	var/mob/user = ui.user
 	var/datum/changeling_bio_incubator/incubator = changeling.bio_incubator
 	switch(action)
-		if("create_build")
-			if(!incubator || !incubator.can_add_build())
-				return FALSE
-			var/default_name = "Matrix Build [incubator.builds.len + 1]"
-			var/new_name = tgui_input_text(user, "Name the new build.", "Create Genetic Matrix Build", default_name, 32)
-			if(isnull(new_name))
-				return FALSE
-			new_name = sanitize_text(new_name)
-			if(!length(new_name))
-				new_name = default_name
-			changeling.add_genetic_matrix_build(new_name)
-			return TRUE
-		if("delete_build")
-			var/datum/changeling_bio_incubator/build/build = changeling.find_genetic_matrix_build(params["build"])
-			if(!build)
-				return FALSE
-			if(tgui_alert(user, "Delete build \"[build.name]\"?", "Remove Build", list("Delete", "Cancel")) != "Delete")
-				return FALSE
-			changeling.remove_genetic_matrix_build(build)
-			return TRUE
-		if("rename_build")
-			var/datum/changeling_bio_incubator/build/build = changeling.find_genetic_matrix_build(params["build"])
-			if(!build)
-				return FALSE
-			var/new_name = tgui_input_text(user, "Enter a new name for this build.", "Rename Build", build.name, 32)
-			if(isnull(new_name))
-				return FALSE
-			new_name = sanitize_text(new_name)
-			if(!length(new_name))
-				return FALSE
-			build.name = new_name
-			build.bio_incubator?.notify_update()
-			return TRUE
-		if("clear_build")
-			var/datum/changeling_bio_incubator/build/build = changeling.find_genetic_matrix_build(params["build"])
-			if(!build)
-				return FALSE
-			changeling.clear_genetic_matrix_build(build)
+                if("clear_build")
+                        var/datum/changeling_bio_incubator/build/build = changeling.find_genetic_matrix_build(params["build"])
+                        if(!build)
+                                return FALSE
+                        changeling.clear_genetic_matrix_build(build)
 			return TRUE
 		if("set_build_module", "set_build_ability")
 			var/datum/changeling_bio_incubator/build/build = changeling.find_genetic_matrix_build(params["build"])
@@ -145,11 +112,11 @@
 			var/module_identifier = params["module"]
 			if(isnull(module_identifier))
 				module_identifier = params["ability"]
-			if(!module_identifier)
-				changeling.assign_genetic_matrix_module(build, null, slot)
-				return TRUE
-			return changeling.assign_genetic_matrix_module(build, module_identifier, slot)
-		if("clear_build_module", "clear_build_ability")
+                        if(!module_identifier)
+                                changeling.assign_genetic_matrix_module(build, null, slot)
+                                return TRUE
+                        return changeling.assign_genetic_matrix_module(build, module_identifier, slot)
+                if("clear_build_module", "clear_build_ability")
 			var/datum/changeling_bio_incubator/build/build = changeling.find_genetic_matrix_build(params["build"])
 			if(!build)
 				return FALSE
@@ -165,16 +132,21 @@
 				return FALSE
 			return changeling.craft_genetic_matrix_module(recipe_id)
 		if("purchase_standard")
-			var/ability_id = params["ability"]
-			if(!ability_id)
-				return FALSE
-			var/datum/action/changeling/ability_path = text2path(ability_id)
-			if(!ispath(ability_path, /datum/action/changeling))
-				return FALSE
-			return changeling.purchase_power(ability_path)
-		if("readapt_standard")
-			return changeling.readapt()
-	return FALSE
+                        var/ability_id = params["ability"]
+                        if(!ability_id)
+                                return FALSE
+                        var/datum/action/changeling/ability_path = text2path(ability_id)
+                        if(!ispath(ability_path, /datum/action/changeling))
+                                return FALSE
+                        return changeling.purchase_power(ability_path)
+                if("readapt_standard")
+                        return changeling.readapt()
+                if("commit_build")
+                        var/datum/changeling_bio_incubator/build/build = changeling.find_genetic_matrix_build(params["build"])
+                        if(!build)
+                                return FALSE
+                        return changeling.commit_genetic_matrix_build(build, user)
+        return FALSE
 
 /datum/action/changeling/genetic_matrix
 	name = "Genetic Matrix"


### PR DESCRIPTION
## Summary
- collapse the changeling genetic matrix into a single configuration with an applied module list
- add a delayed genome rewrite flow that applies pending modules after a do_after sequence
- refresh the TGUI to remove build management, surface pending changes, and provide a save action tied to the new workflow

## Testing
- `npx biome lint tgui/packages/tgui/interfaces/GeneticMatrix.tsx`
- `npm run tgui:lint` *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cffb38ec14832a851fca6c540a58a9