### PR TITLE
Fix changeling DreamMaker indentation errors

### DIFF
--- a/code/modules/antagonists/changeling/bio_incubator.dm
+++ b/code/modules/antagonists/changeling/bio_incubator.dm
@@ -12,33 +12,33 @@
 
 /// Stores changeling genetic matrix inventory and build configuration.
 /datum/changeling_bio_incubator
-        /// Owning changeling datum.
-        var/datum/antagonist/changeling/changeling
-        /// Unique identifiers for collected cell signatures.
-        var/list/cell_ids = list()
-        /// Unique identifiers for known crafting recipes.
-        var/list/recipe_ids = list()
-        /// Assoc list of crafted module definitions indexed by identifier.
-        var/list/crafted_modules = list()
-        /// Stored build presets.
-        var/list/datum/changeling_bio_incubator/build/builds = list()
-        /// Currently applied module identifiers indexed by slot.
-        var/list/active_module_ids = list()
+	/// Owning changeling datum.
+	var/datum/antagonist/changeling/changeling
+	/// Unique identifiers for collected cell signatures.
+	var/list/cell_ids = list()
+	/// Unique identifiers for known crafting recipes.
+	var/list/recipe_ids = list()
+	/// Assoc list of crafted module definitions indexed by identifier.
+	var/list/crafted_modules = list()
+	/// Stored build presets.
+	var/list/datum/changeling_bio_incubator/build/builds = list()
+	/// Currently applied module identifiers indexed by slot.
+	var/list/active_module_ids = list()
 
 /datum/changeling_bio_incubator/New(datum/antagonist/changeling/changeling)
-        . = ..()
-        src.changeling = changeling
-        ensure_active_capacity()
+	. = ..()
+	src.changeling = changeling
+	ensure_active_capacity()
 
 /datum/changeling_bio_incubator/Destroy()
-        cell_ids = null
-        recipe_ids = null
-        crafted_modules = null
-        QDEL_LIST(builds)
-        builds = null
-        active_module_ids = null
-        changeling = null
-        return ..()
+	cell_ids = null
+	recipe_ids = null
+	crafted_modules = null
+	QDEL_LIST(builds)
+	builds = null
+	active_module_ids = null
+	changeling = null
+	return ..()
 
 /datum/changeling_bio_incubator/proc/get_max_builds()
 	return BIO_INCUBATOR_MAX_BUILDS
@@ -50,41 +50,41 @@
 	return builds.len < get_max_builds()
 
 /datum/changeling_bio_incubator/proc/ensure_default_build()
-        var/changed = FALSE
-        if(builds.len > 1)
-                for(var/i in 2 to builds.len)
-                        var/datum/changeling_bio_incubator/build/extra = builds[i]
-                        if(!extra)
-                                continue
-                        qdel(extra)
-                builds.Cut(2, builds.len + 1)
-                changed = TRUE
-        if(!builds.len)
-                var/datum/changeling_bio_incubator/build/build = new(src)
-                build.name = "Genetic Matrix"
-                build.ensure_slot_capacity()
-                builds += list(build)
-                changed = TRUE
-        var/datum/changeling_bio_incubator/build/primary = builds[1]
-        if(primary)
-                primary.ensure_slot_capacity()
-        ensure_active_capacity()
-        if(!active_module_ids.len)
-                apply_build_configuration(primary, notify = FALSE)
-        else
-                sanitize_active_modules()
-        if(changed)
-                notify_update(BIO_INCUBATOR_UPDATE_BUILDS)
+	var/changed = FALSE
+	if(builds.len > 1)
+		for(var/i in 2 to builds.len)
+			var/datum/changeling_bio_incubator/build/extra = builds[i]
+			if(!extra)
+				continue
+			qdel(extra)
+		builds.Cut(2, builds.len + 1)
+		changed = TRUE
+	if(!builds.len)
+		var/datum/changeling_bio_incubator/build/build = new(src)
+		build.name = "Genetic Matrix"
+		build.ensure_slot_capacity()
+		builds += list(build)
+		changed = TRUE
+	var/datum/changeling_bio_incubator/build/primary = builds[1]
+	if(primary)
+		primary.ensure_slot_capacity()
+	ensure_active_capacity()
+	if(!active_module_ids.len)
+		apply_build_configuration(primary, notify = FALSE)
+	else
+		sanitize_active_modules()
+	if(changed)
+		notify_update(BIO_INCUBATOR_UPDATE_BUILDS)
 
 /datum/changeling_bio_incubator/proc/add_build(name)
-        if(!can_add_build())
-                return null
-        var/datum/changeling_bio_incubator/build/build = new(src)
-        build.name = name
-        build.ensure_slot_capacity()
-        builds += list(build)
-        notify_update(BIO_INCUBATOR_UPDATE_BUILDS)
-        return build
+	if(!can_add_build())
+		return null
+	var/datum/changeling_bio_incubator/build/build = new(src)
+	build.name = name
+	build.ensure_slot_capacity()
+	builds += list(build)
+	notify_update(BIO_INCUBATOR_UPDATE_BUILDS)
+	return build
 
 /datum/changeling_bio_incubator/proc/remove_build(datum/changeling_bio_incubator/build/build)
 	if(!build)
@@ -110,29 +110,29 @@
 	return null
 
 /datum/changeling_bio_incubator/proc/get_builds_data()
-        var/list/output = list()
-        for(var/datum/changeling_bio_incubator/build/build as anything in builds)
-                output += list(build.to_data())
-        return output
+	var/list/output = list()
+	for(var/datum/changeling_bio_incubator/build/build as anything in builds)
+		output += list(build.to_data())
+	return output
 
 /datum/changeling_bio_incubator/proc/prune_assignments()
-        for(var/datum/changeling_bio_incubator/build/build as anything in builds)
-                build.ensure_slot_capacity()
-                for(var/i in 1 to build.module_ids.len)
+	for(var/datum/changeling_bio_incubator/build/build as anything in builds)
+		build.ensure_slot_capacity()
+		for(var/i in 1 to build.module_ids.len)
 			var/module_id = build.module_ids[i]
 			if(!module_id)
 				continue
-                        if(!changeling?.has_genetic_matrix_module(module_id))
-                                build.module_ids[i] = null
-                                continue
-                        if(!module_slot_allowed(module_id, i))
-                                build.module_ids[i] = null
-        sanitize_active_modules()
+			if(!changeling?.has_genetic_matrix_module(module_id))
+				build.module_ids[i] = null
+				continue
+			if(!module_slot_allowed(module_id, i))
+				build.module_ids[i] = null
+	sanitize_active_modules()
 
 /datum/changeling_bio_incubator/proc/assign_module(datum/changeling_bio_incubator/build/build, module_identifier, slot)
-        if(!build)
-                return FALSE
-        build.ensure_slot_capacity()
+	if(!build)
+		return FALSE
+	build.ensure_slot_capacity()
 	if(slot < 1 || slot > get_max_slots())
 		return FALSE
 	if(isnull(module_identifier))
@@ -254,26 +254,26 @@
 	data_copy["exclusiveTags"] = sanitize_tag_list(data_copy["exclusiveTags"])
 	if(!data_copy["source"])
 		data_copy["source"] = "crafted"
-        crafted_modules[module_id] = data_copy
-        notify_update(BIO_INCUBATOR_UPDATE_MODULES)
-        return TRUE
+	crafted_modules[module_id] = data_copy
+	notify_update(BIO_INCUBATOR_UPDATE_MODULES)
+	return TRUE
 
 /datum/changeling_bio_incubator/proc/unregister_module(module_id)
-        module_id = sanitize_module_id(module_id)
-        if(!crafted_modules[module_id])
-                return FALSE
-        del crafted_modules[module_id]
-        ensure_active_capacity()
-        var/changed = FALSE
-        for(var/i in 1 to active_module_ids.len)
-                if(active_module_ids[i] != module_id)
-                        continue
-                active_module_ids[i] = null
-                changed = TRUE
-        if(changed)
-                notify_update(BIO_INCUBATOR_UPDATE_BUILDS)
-        notify_update(BIO_INCUBATOR_UPDATE_MODULES | BIO_INCUBATOR_UPDATE_BUILDS)
-        return TRUE
+	module_id = sanitize_module_id(module_id)
+	if(!crafted_modules[module_id])
+		return FALSE
+	del crafted_modules[module_id]
+	ensure_active_capacity()
+	var/changed = FALSE
+	for(var/i in 1 to active_module_ids.len)
+		if(active_module_ids[i] != module_id)
+			continue
+		active_module_ids[i] = null
+		changed = TRUE
+	if(changed)
+		notify_update(BIO_INCUBATOR_UPDATE_BUILDS)
+	notify_update(BIO_INCUBATOR_UPDATE_MODULES | BIO_INCUBATOR_UPDATE_BUILDS)
+	return TRUE
 
 /datum/changeling_bio_incubator/proc/has_module(module_id)
 	module_id = sanitize_module_id(module_id)
@@ -289,86 +289,86 @@
 	return catalog
 
 /datum/changeling_bio_incubator/proc/get_module_data(module_id)
-        module_id = sanitize_module_id(module_id)
-        if(isnull(module_id))
-                return null
-        var/list/entry = crafted_modules[module_id]
-        if(islist(entry))
-                return entry.Copy()
-        return null
+	module_id = sanitize_module_id(module_id)
+	if(isnull(module_id))
+		return null
+	var/list/entry = crafted_modules[module_id]
+	if(islist(entry))
+		return entry.Copy()
+	return null
 
 /datum/changeling_bio_incubator/proc/ensure_active_capacity()
-        var/max_slots = get_max_slots()
-        if(!islist(active_module_ids))
-                active_module_ids = list()
-        if(max_slots <= 0)
-                active_module_ids.Cut()
-                return
-        while(active_module_ids.len < max_slots)
-                active_module_ids += null
-        if(active_module_ids.len > max_slots)
-                active_module_ids.Cut(max_slots + 1, active_module_ids.len + 1)
+	var/max_slots = get_max_slots()
+	if(!islist(active_module_ids))
+		active_module_ids = list()
+	if(max_slots <= 0)
+		active_module_ids.Cut()
+		return
+	while(active_module_ids.len < max_slots)
+		active_module_ids += null
+	if(active_module_ids.len > max_slots)
+		active_module_ids.Cut(max_slots + 1, active_module_ids.len + 1)
 
 /datum/changeling_bio_incubator/proc/get_active_module_ids()
-        ensure_active_capacity()
-        return active_module_ids.Copy()
+	ensure_active_capacity()
+	return active_module_ids.Copy()
 
 /datum/changeling_bio_incubator/proc/is_module_active(module_identifier)
-        if(isnull(module_identifier))
-                return FALSE
-        ensure_active_capacity()
-        var/id_text = sanitize_module_id(module_identifier)
-        if(!id_text)
-                return FALSE
-        for(var/module_id in active_module_ids)
-                if(module_id != id_text)
-                        continue
-                return TRUE
-        return FALSE
+	if(isnull(module_identifier))
+		return FALSE
+	ensure_active_capacity()
+	var/id_text = sanitize_module_id(module_identifier)
+	if(!id_text)
+		return FALSE
+	for(var/module_id in active_module_ids)
+		if(module_id != id_text)
+			continue
+		return TRUE
+	return FALSE
 
 /datum/changeling_bio_incubator/proc/apply_build_configuration(datum/changeling_bio_incubator/build/build, notify = TRUE)
-        if(!build)
-                return FALSE
-        ensure_active_capacity()
-        build.ensure_slot_capacity()
-        var/max_slots = get_max_slots()
-        var/list/new_active = list()
-        for(var/i in 1 to max_slots)
-                var/module_id = null
-                if(i <= build.module_ids.len)
-                        module_id = sanitize_module_id(build.module_ids[i])
-                if(module_id && (!has_module(module_id) || !module_slot_allowed(module_id, i)))
-                        module_id = null
-                new_active += module_id
-        var/changed = FALSE
-        if(active_module_ids.len != new_active.len)
-                changed = TRUE
-        else
-                for(var/i in 1 to new_active.len)
-                        if(active_module_ids[i] == new_active[i])
-                                continue
-                        changed = TRUE
-                        break
-        active_module_ids = new_active
-        if(changed && notify)
-                notify_update(BIO_INCUBATOR_UPDATE_BUILDS)
-        else if(!changed)
-                ensure_active_capacity()
-        return TRUE
+	if(!build)
+		return FALSE
+	ensure_active_capacity()
+	build.ensure_slot_capacity()
+	var/max_slots = get_max_slots()
+	var/list/new_active = list()
+	for(var/i in 1 to max_slots)
+		var/module_id = null
+		if(i <= build.module_ids.len)
+			module_id = sanitize_module_id(build.module_ids[i])
+		if(module_id && (!has_module(module_id) || !module_slot_allowed(module_id, i)))
+			module_id = null
+		new_active += module_id
+	var/changed = FALSE
+	if(active_module_ids.len != new_active.len)
+		changed = TRUE
+	else
+		for(var/i in 1 to new_active.len)
+			if(active_module_ids[i] == new_active[i])
+				continue
+			changed = TRUE
+			break
+	active_module_ids = new_active
+	if(changed && notify)
+		notify_update(BIO_INCUBATOR_UPDATE_BUILDS)
+	else if(!changed)
+		ensure_active_capacity()
+	return TRUE
 
 /datum/changeling_bio_incubator/proc/sanitize_active_modules()
-        ensure_active_capacity()
-        var/changed = FALSE
-        for(var/i in 1 to active_module_ids.len)
-                var/module_id = active_module_ids[i]
-                if(!module_id)
-                        continue
-                if(!has_module(module_id) || !module_slot_allowed(module_id, i))
-                        active_module_ids[i] = null
-                        changed = TRUE
-        if(changed)
-                notify_update(BIO_INCUBATOR_UPDATE_BUILDS)
-        return changed
+	ensure_active_capacity()
+	var/changed = FALSE
+	for(var/i in 1 to active_module_ids.len)
+		var/module_id = active_module_ids[i]
+		if(!module_id)
+			continue
+		if(!has_module(module_id) || !module_slot_allowed(module_id, i))
+			active_module_ids[i] = null
+			changed = TRUE
+	if(changed)
+		notify_update(BIO_INCUBATOR_UPDATE_BUILDS)
+	return changed
 
 /datum/changeling_bio_incubator/proc/add_cell(cell_identifier)
 	var/cell_id = changeling_normalize_cell_id(cell_identifier)
@@ -485,30 +485,30 @@
 	return TRUE
 
 /datum/changeling_bio_incubator/build/proc/to_data()
-        var/list/data = list(
-                "id" = REF(src),
-                "name" = name,
-        )
-        ensure_slot_capacity()
-        var/list/active_ids = bio_incubator?.get_active_module_ids() || list()
-        data["activeModuleIds"] = active_ids.Copy()
-        var/list/module_data = list()
-        for(var/i in 1 to module_ids.len)
-                var/module_id = module_ids[i]
-                if(!module_id)
-                        module_data += list(null)
-                        continue
-                var/list/entry = bio_incubator?.get_module_data(module_id)
-                if(!entry)
-                        module_ids[i] = null
-                        module_data += list(null)
-                        continue
-                entry = entry.Copy()
-                entry["slot"] = i
-                entry["active"] = (i <= active_ids.len) && active_ids[i] == module_id
-                module_data += list(entry)
-        data["modules"] = module_data
-        return data
+	var/list/data = list(
+		"id" = REF(src),
+		"name" = name,
+	)
+	ensure_slot_capacity()
+	var/list/active_ids = bio_incubator?.get_active_module_ids() || list()
+	data["activeModuleIds"] = active_ids.Copy()
+	var/list/module_data = list()
+	for(var/i in 1 to module_ids.len)
+		var/module_id = module_ids[i]
+		if(!module_id)
+			module_data += list(null)
+			continue
+		var/list/entry = bio_incubator?.get_module_data(module_id)
+		if(!entry)
+			module_ids[i] = null
+			module_data += list(null)
+			continue
+		entry = entry.Copy()
+		entry["slot"] = i
+		entry["active"] = (i <= active_ids.len) && active_ids[i] == module_id
+		module_data += list(entry)
+	data["modules"] = module_data
+	return data
 
 #undef BIO_INCUBATOR_MAX_MODULE_SLOTS
 #undef BIO_INCUBATOR_MAX_BUILDS

--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -72,10 +72,10 @@
 	var/datum/genetic_matrix/genetic_matrix
 	/// Action that opens the genetic matrix UI.
 	var/datum/action/changeling/genetic_matrix/genetic_matrix_action
-        /// Storage managing cytology cells, recipes, modules, and builds.
-        var/datum/changeling_bio_incubator/bio_incubator
-        /// Whether the changeling is currently rewriting their genetic matrix.
-        var/genetic_matrix_reconfiguring = FALSE
+	/// Storage managing cytology cells, recipes, modules, and builds.
+	var/datum/changeling_bio_incubator/bio_incubator
+	/// Whether the changeling is currently rewriting their genetic matrix.
+	var/genetic_matrix_reconfiguring = FALSE
 
 	/// UI displaying how many chems we have
 	var/atom/movable/screen/ling/chems/lingchemdisplay
@@ -236,89 +236,89 @@
 		to_chat(owner.current, span_userdanger("You grow weak and lose your powers! You are no longer a changeling and are stuck in your current form!"))
 
 /*
- * Instantiate the cellular emporium for the changeling.
- */
+* Instantiate the cellular emporium for the changeling.
+*/
 /datum/antagonist/changeling/proc/create_emporium()
 	cellular_emporium = new(src)
 	emporium_action = new(cellular_emporium)
 	emporium_action.Grant(owner.current)
 
 /datum/antagonist/changeling/proc/create_bio_incubator()
-        QDEL_NULL(bio_incubator)
-        bio_incubator = new(src)
-        bio_incubator.ensure_default_build()
-        update_genetic_matrix_unlocks()
-        if(genetic_matrix)
-                genetic_matrix.register_with_incubator()
-        genetic_matrix_reconfiguring = FALSE
-        return bio_incubator
+	QDEL_NULL(bio_incubator)
+	bio_incubator = new(src)
+	bio_incubator.ensure_default_build()
+	update_genetic_matrix_unlocks()
+	if(genetic_matrix)
+		genetic_matrix.register_with_incubator()
+	genetic_matrix_reconfiguring = FALSE
+	return bio_incubator
 
 /datum/antagonist/changeling/proc/create_genetic_matrix()
-        QDEL_NULL(genetic_matrix_action)
-        QDEL_NULL(genetic_matrix)
-        if(!bio_incubator)
-                create_bio_incubator()
-        genetic_matrix = new(src)
-        genetic_matrix_action = new(genetic_matrix)
-        ensure_genetic_matrix_setup()
-        update_genetic_matrix_unlocks()
-        if(owner && owner.current)
-                genetic_matrix_action.Grant(owner.current)
+	QDEL_NULL(genetic_matrix_action)
+	QDEL_NULL(genetic_matrix)
+	if(!bio_incubator)
+		create_bio_incubator()
+	genetic_matrix = new(src)
+	genetic_matrix_action = new(genetic_matrix)
+	ensure_genetic_matrix_setup()
+	update_genetic_matrix_unlocks()
+	if(owner && owner.current)
+		genetic_matrix_action.Grant(owner.current)
 
 /datum/antagonist/changeling/proc/is_genetic_matrix_reconfiguring()
-        return genetic_matrix_reconfiguring
+	return genetic_matrix_reconfiguring
 
 /datum/antagonist/changeling/proc/commit_genetic_matrix_build(datum/changeling_bio_incubator/build/build, mob/user)
-        if(!build || !owner?.current)
-                return FALSE
-        if(!bio_incubator)
-                create_bio_incubator()
-        if(!bio_incubator)
-                return FALSE
-        var/mob/living/living_owner = owner.current
-        if(genetic_matrix_reconfiguring)
-                living_owner.balloon_alert(living_owner, "already reconfiguring!")
-                return FALSE
-        var/list/current_active = bio_incubator.get_active_module_ids()
-        var/has_changes = FALSE
-        var/max_slots = bio_incubator.get_max_slots()
-        build.ensure_slot_capacity()
-        for(var/i in 1 to max_slots)
-                var/current_id = i <= current_active.len ? current_active[i] : null
-                var/new_id = i <= build.module_ids.len ? build.module_ids[i] : null
-                if(new_id)
-                        new_id = bio_incubator.sanitize_module_id(new_id)
-                if(current_id != new_id)
-                        has_changes = TRUE
-                        break
-        if(!has_changes)
-                living_owner.balloon_alert(living_owner, "no changes to apply")
-                return FALSE
-        genetic_matrix_reconfiguring = TRUE
-        if(genetic_matrix)
-                SStgui.update_uis(genetic_matrix)
-        to_chat(living_owner, span_notice("We focus inward, preparing to rewrite our genome."))
-        if(!do_after(living_owner, 15 SECONDS, living_owner))
-                genetic_matrix_reconfiguring = FALSE
-                if(genetic_matrix)
-                        SStgui.update_uis(genetic_matrix)
-                living_owner.balloon_alert(living_owner, "interrupted!")
-                return FALSE
-        bio_incubator.apply_build_configuration(build)
-        genetic_matrix_reconfiguring = FALSE
-        if(genetic_matrix)
-                SStgui.update_uis(genetic_matrix)
-        to_chat(living_owner, span_notice("Our passive adaptations settle into place."))
-        on_genetic_matrix_reconfigured()
-        return TRUE
+	if(!build || !owner?.current)
+		return FALSE
+	if(!bio_incubator)
+		create_bio_incubator()
+	if(!bio_incubator)
+		return FALSE
+	var/mob/living/living_owner = owner.current
+	if(genetic_matrix_reconfiguring)
+		living_owner.balloon_alert(living_owner, "already reconfiguring!")
+		return FALSE
+	var/list/current_active = bio_incubator.get_active_module_ids()
+	var/has_changes = FALSE
+	var/max_slots = bio_incubator.get_max_slots()
+	build.ensure_slot_capacity()
+	for(var/i in 1 to max_slots)
+		var/current_id = i <= current_active.len ? current_active[i] : null
+		var/new_id = i <= build.module_ids.len ? build.module_ids[i] : null
+		if(new_id)
+			new_id = bio_incubator.sanitize_module_id(new_id)
+		if(current_id != new_id)
+			has_changes = TRUE
+			break
+	if(!has_changes)
+		living_owner.balloon_alert(living_owner, "no changes to apply")
+		return FALSE
+	genetic_matrix_reconfiguring = TRUE
+	if(genetic_matrix)
+		SStgui.update_uis(genetic_matrix)
+	to_chat(living_owner, span_notice("We focus inward, preparing to rewrite our genome."))
+	if(!do_after(living_owner, 15 SECONDS, living_owner))
+		genetic_matrix_reconfiguring = FALSE
+		if(genetic_matrix)
+			SStgui.update_uis(genetic_matrix)
+		living_owner.balloon_alert(living_owner, "interrupted!")
+		return FALSE
+	bio_incubator.apply_build_configuration(build)
+	genetic_matrix_reconfiguring = FALSE
+	if(genetic_matrix)
+		SStgui.update_uis(genetic_matrix)
+	to_chat(living_owner, span_notice("Our passive adaptations settle into place."))
+	on_genetic_matrix_reconfigured()
+	return TRUE
 
 /datum/antagonist/changeling/proc/on_genetic_matrix_reconfigured()
-        update_genetic_matrix_unlocks()
+	update_genetic_matrix_unlocks()
 
 /*
- * Instantiate all the default actions of a ling (transform, dna sting, absorb, etc)
- * Any Changeling action with dna_cost = CHANGELING_POWER_INNATE will be added here automatically
- */
+* Instantiate all the default actions of a ling (transform, dna sting, absorb, etc)
+* Any Changeling action with dna_cost = CHANGELING_POWER_INNATE will be added here automatically
+*/
 /datum/antagonist/changeling/proc/create_innate_actions()
 	for(var/datum/action/changeling/path as anything in all_powers)
 		if(initial(path.dna_cost) != CHANGELING_POWER_INNATE)
@@ -330,9 +330,9 @@
 	update_genetic_matrix_unlocks()
 
 /*
- * Signal proc for [COMSIG_MOB_LOGIN].
- * Gives us back our action buttons if we lose them on log-in.
- */
+* Signal proc for [COMSIG_MOB_LOGIN].
+* Gives us back our action buttons if we lose them on log-in.
+*/
 /datum/antagonist/changeling/proc/on_login(datum/source)
 	SIGNAL_HANDLER
 
@@ -345,9 +345,9 @@
 	regain_powers()
 
 /**
- * Signal proc for [COMSIG_LIVING_LIFE].
- * Handles regenerating chemicals on life ticks.
- */
+* Signal proc for [COMSIG_LIVING_LIFE].
+* Handles regenerating chemicals on life ticks.
+*/
 /datum/antagonist/changeling/proc/on_life(datum/source, seconds_per_tick, times_fired)
 	SIGNAL_HANDLER
 
@@ -366,8 +366,8 @@
 			adjust_chemicals((chem_recharge_rate - chem_recharge_slowdown) * delta_time)
 
 /**
- * Signal proc for [COMSIG_LIVING_POST_FULLY_HEAL]
- */
+* Signal proc for [COMSIG_LIVING_POST_FULLY_HEAL]
+*/
 /datum/antagonist/changeling/proc/on_fullhealed(mob/living/source, heal_flags)
 	SIGNAL_HANDLER
 
@@ -379,9 +379,9 @@
 	make_brain_decoy(source)
 
 /**
- * Signal proc for [COMSIG_MOB_MIDDLECLICKON] and [COMSIG_MOB_ALTCLICKON].
- * Allows the changeling to sting people with a click.
- */
+* Signal proc for [COMSIG_MOB_MIDDLECLICKON] and [COMSIG_MOB_ALTCLICKON].
+* Allows the changeling to sting people with a click.
+*/
 /datum/antagonist/changeling/proc/on_click_sting(mob/living/ling, atom/clicked)
 	SIGNAL_HANDLER
 
@@ -412,9 +412,9 @@
 	items += "Absorbed DNA: [absorbed_count]"
 
 /*
- * Adjust the chem charges of the ling by [amount]
- * and clamp it between 0 and override_cap (if supplied) or total_chem_storage (if no override supplied)
- */
+* Adjust the chem charges of the ling by [amount]
+* and clamp it between 0 and override_cap (if supplied) or total_chem_storage (if no override supplied)
+*/
 /datum/antagonist/changeling/proc/adjust_chemicals(amount, override_cap)
 	if(!isnum(amount))
 		return
@@ -424,10 +424,10 @@
 	lingchemdisplay?.maptext = FORMAT_CHEM_CHARGES_TEXT(chem_charges)
 
 /*
- * Remove changeling powers from the current Changeling's purchased_powers list.
- *
- * if [include_innate] = TRUE, will also remove all powers from the Changeling's innate_powers list.
- */
+* Remove changeling powers from the current Changeling's purchased_powers list.
+*
+* if [include_innate] = TRUE, will also remove all powers from the Changeling's innate_powers list.
+*/
 /datum/antagonist/changeling/proc/remove_changeling_powers(include_innate = FALSE)
 	if(!isliving(owner.current))
 		return
@@ -447,8 +447,8 @@
 	update_genetic_matrix_unlocks()
 
 /*
- * For resetting all of the changeling's action buttons. (IE, re-granting them all.)
- */
+* For resetting all of the changeling's action buttons. (IE, re-granting them all.)
+*/
 /datum/antagonist/changeling/proc/regain_powers()
 	emporium_action.Grant(owner.current)
 	if(genetic_matrix_action)
@@ -462,10 +462,10 @@
 			power.on_purchase(owner.current)
 
 /*
- * The act of purchasing a certain power for a changeling.
- *
- * [sting_path] - the power that's being purchased / evolved.
- */
+* The act of purchasing a certain power for a changeling.
+*
+* [sting_path] - the power that's being purchased / evolved.
+*/
 /datum/antagonist/changeling/proc/purchase_power(datum/action/changeling/sting_path)
 	if(!ispath(sting_path, /datum/action/changeling))
 		CRASH("Changeling purchase_power attempted to purchase an invalid typepath! (got: [sting_path])")
@@ -501,14 +501,14 @@
 	return success
 
 /**
- * Gives a passed changeling power datum to the player
- *
- * Is passed a path to a changeling power, and applies it to the user.
- * If successful, we return TRUE, otherwise not.
- *
- * Arguments:
- * * power_path - The path of the power we will be giving to our attached player.
- */
+* Gives a passed changeling power datum to the player
+*
+* Is passed a path to a changeling power, and applies it to the user.
+* If successful, we return TRUE, otherwise not.
+*
+* Arguments:
+* * power_path - The path of the power we will be giving to our attached player.
+*/
 
 /datum/antagonist/changeling/proc/give_power(power_path)
 	var/datum/action/changeling/new_action = new power_path()
@@ -526,8 +526,8 @@
 	return TRUE
 
 /*
- * Changeling's ability to re-adapt all of their learned powers.
- */
+* Changeling's ability to re-adapt all of their learned powers.
+*/
 /datum/antagonist/changeling/proc/readapt()
 	if(!ishuman(owner.current) || ismonkey(owner.current))
 		to_chat(owner.current, span_warning("We can't remove our evolutions in this form!"))
@@ -549,16 +549,16 @@
 	return TRUE
 
 /*
- * Get the corresponding changeling profile for the passed name.
- */
+* Get the corresponding changeling profile for the passed name.
+*/
 /datum/antagonist/changeling/proc/get_dna(searched_dna_name)
 	for(var/datum/changeling_profile/found_profile as anything in stored_profiles)
 		if(searched_dna_name == found_profile.name)
 			return found_profile
 
 /*
- * Checks if we have a changeling profile with the passed DNA.
- */
+* Checks if we have a changeling profile with the passed DNA.
+*/
 /datum/antagonist/changeling/proc/has_profile_with_dna(datum/dna/searched_dna)
 	for(var/datum/changeling_profile/found_profile as anything in stored_profiles)
 		if(searched_dna.is_same_as(found_profile.dna))
@@ -566,9 +566,9 @@
 	return FALSE
 
 /*
- * Checks if this changeling can absorb the DNA of [target].
- * if [verbose] = TRUE, give feedback as to why they cannot absorb the DNA.
- */
+* Checks if this changeling can absorb the DNA of [target].
+* if [verbose] = TRUE, give feedback as to why they cannot absorb the DNA.
+*/
 /datum/antagonist/changeling/proc/can_absorb_dna(mob/living/carbon/human/target, verbose = TRUE)
 	if(!target)
 		return FALSE
@@ -612,11 +612,11 @@
 	return TRUE
 
 /*
- * Create a new changeling profile datum based off of [target].
- *
- * target - the human we're basing the new profile off of.
- * protect - if TRUE, set the new profile to protected, preventing it from being removed (without force).
- */
+* Create a new changeling profile datum based off of [target].
+*
+* target - the human we're basing the new profile off of.
+* protect - if TRUE, set the new profile to protected, preventing it from being removed (without force).
+*/
 /datum/antagonist/changeling/proc/create_profile(mob/living/carbon/human/target, protect = 0)
 	var/datum/changeling_profile/new_profile = new()
 
@@ -709,11 +709,11 @@
 	return new_profile
 
 /*
- * Add a new profile to our changeling's profile list.
- * Pops the first profile in the list if we're above our limit of profiles.
- *
- * new_profile - the profile being added.
- */
+* Add a new profile to our changeling's profile list.
+* Pops the first profile in the list if we're above our limit of profiles.
+*
+* new_profile - the profile being added.
+*/
 /datum/antagonist/changeling/proc/add_profile(datum/changeling_profile/new_profile)
 	if(stored_profiles.len > dna_max)
 		if(!push_out_profile())
@@ -727,23 +727,23 @@
 	absorbed_count++
 
 /*
- * Create a new profile from the given [profile_target]
- * and add it to our profile list via add_profile.
- *
- * profile_target - the human we're making a profile based off of
- * protect - if TRUE, mark the new profile as protected. If protected, it cannot be removed / popped from the profile list (without force).
- */
+* Create a new profile from the given [profile_target]
+* and add it to our profile list via add_profile.
+*
+* profile_target - the human we're making a profile based off of
+* protect - if TRUE, mark the new profile as protected. If protected, it cannot be removed / popped from the profile list (without force).
+*/
 /datum/antagonist/changeling/proc/add_new_profile(mob/living/carbon/human/profile_target, protect = FALSE)
 	var/datum/changeling_profile/new_profile = create_profile(profile_target, protect)
 	add_profile(new_profile)
 	return new_profile
 
 /*
- * Remove a given profile from the profile list.
- *  *
- * profile_target - the human we want to remove from our profile list (looks for a profile with a matching name)
- * force - if TRUE, removes the profile even if it's protected.
- */
+* Remove a given profile from the profile list.
+*  *
+* profile_target - the human we want to remove from our profile list (looks for a profile with a matching name)
+* force - if TRUE, removes the profile even if it's protected.
+*/
 /datum/antagonist/changeling/proc/remove_profile(mob/living/carbon/human/profile_target, force = FALSE)
 	for(var/datum/changeling_profile/found_profile as anything in stored_profiles)
 		if(profile_target.real_name == found_profile.name)
@@ -753,11 +753,11 @@
 			qdel(found_profile)
 
 /*
- * Removes the highest changeling profile from the list
- * that isn't protected and returns TRUE if successful.
- *
- * Returns TRUE if a profile was removed, FALSE otherwise.
- */
+* Removes the highest changeling profile from the list
+* that isn't protected and returns TRUE if successful.
+*
+* Returns TRUE if a profile was removed, FALSE otherwise.
+*/
 /datum/antagonist/changeling/proc/push_out_profile()
 	var/datum/changeling_profile/profile_to_remove
 	for(var/datum/changeling_profile/found_profile as anything in stored_profiles)
@@ -772,8 +772,8 @@
 	return FALSE
 
 /*
- * Create a profile based on the changeling's initial appearance.
- */
+* Create a profile based on the changeling's initial appearance.
+*/
 /datum/antagonist/changeling/proc/create_initial_profile()
 	if(!ishuman(owner.current))
 		return
@@ -853,8 +853,8 @@
 		.["Transform to initial appearance."] = CALLBACK(src, PROC_REF(admin_restore_appearance))
 
 /*
- * Restores the appearance of the changeling to the original DNA.
- */
+* Restores the appearance of the changeling to the original DNA.
+*/
 /datum/antagonist/changeling/proc/admin_restore_appearance(mob/admin)
 	if(!stored_profiles.len || !iscarbon(owner.current))
 		to_chat(admin, span_danger("Resetting DNA failed!"))
@@ -867,8 +867,8 @@
 	carbon_owner.domutcheck()
 
 /*
- * Transform the currentc hangeing [user] into the [chosen_profile].
- */
+* Transform the currentc hangeing [user] into the [chosen_profile].
+*/
 /datum/antagonist/changeling/proc/transform(mob/living/carbon/human/user, datum/changeling_profile/chosen_profile)
 	var/static/list/slot2slot = list(
 		"head" = ITEM_SLOT_HEAD,
@@ -1105,9 +1105,9 @@
 	return ..()
 
 /*
- * Copy every aspect of this file into a new instance of a profile.
- * Must be suppied with an instance.
- */
+* Copy every aspect of this file into a new instance of a profile.
+* Must be suppied with an instance.
+*/
 /datum/changeling_profile/proc/copy_profile(datum/changeling_profile/new_profile)
 	new_profile.name = name
 	new_profile.protected = protected

--- a/code/modules/antagonists/changeling/genetic_matrix.dm
+++ b/code/modules/antagonists/changeling/genetic_matrix.dm
@@ -82,9 +82,9 @@
 	data["geneticPoints"] = changeling.genetic_points
 	data["absorbs"] = changeling.true_absorbs
 	data["dnaSamples"] = changeling.absorbed_count
-        data["canReadapt"] = changeling.can_respec
-        data["isReconfiguring"] = changeling.is_genetic_matrix_reconfiguring()
-        return data
+	data["canReadapt"] = changeling.can_respec
+	data["isReconfiguring"] = changeling.is_genetic_matrix_reconfiguring()
+	return data
 
 /datum/genetic_matrix/ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)
 	. = ..()
@@ -95,11 +95,11 @@
 	var/mob/user = ui.user
 	var/datum/changeling_bio_incubator/incubator = changeling.bio_incubator
 	switch(action)
-                if("clear_build")
-                        var/datum/changeling_bio_incubator/build/build = changeling.find_genetic_matrix_build(params["build"])
-                        if(!build)
-                                return FALSE
-                        changeling.clear_genetic_matrix_build(build)
+		if("clear_build")
+			var/datum/changeling_bio_incubator/build/build = changeling.find_genetic_matrix_build(params["build"])
+			if(!build)
+				return FALSE
+			changeling.clear_genetic_matrix_build(build)
 			return TRUE
 		if("set_build_module", "set_build_ability")
 			var/datum/changeling_bio_incubator/build/build = changeling.find_genetic_matrix_build(params["build"])
@@ -112,11 +112,11 @@
 			var/module_identifier = params["module"]
 			if(isnull(module_identifier))
 				module_identifier = params["ability"]
-                        if(!module_identifier)
-                                changeling.assign_genetic_matrix_module(build, null, slot)
-                                return TRUE
-                        return changeling.assign_genetic_matrix_module(build, module_identifier, slot)
-                if("clear_build_module", "clear_build_ability")
+			if(!module_identifier)
+				changeling.assign_genetic_matrix_module(build, null, slot)
+				return TRUE
+			return changeling.assign_genetic_matrix_module(build, module_identifier, slot)
+		if("clear_build_module", "clear_build_ability")
 			var/datum/changeling_bio_incubator/build/build = changeling.find_genetic_matrix_build(params["build"])
 			if(!build)
 				return FALSE
@@ -132,21 +132,21 @@
 				return FALSE
 			return changeling.craft_genetic_matrix_module(recipe_id)
 		if("purchase_standard")
-                        var/ability_id = params["ability"]
-                        if(!ability_id)
-                                return FALSE
-                        var/datum/action/changeling/ability_path = text2path(ability_id)
-                        if(!ispath(ability_path, /datum/action/changeling))
-                                return FALSE
-                        return changeling.purchase_power(ability_path)
-                if("readapt_standard")
-                        return changeling.readapt()
-                if("commit_build")
-                        var/datum/changeling_bio_incubator/build/build = changeling.find_genetic_matrix_build(params["build"])
-                        if(!build)
-                                return FALSE
-                        return changeling.commit_genetic_matrix_build(build, user)
-        return FALSE
+			var/ability_id = params["ability"]
+			if(!ability_id)
+				return FALSE
+			var/datum/action/changeling/ability_path = text2path(ability_id)
+			if(!ispath(ability_path, /datum/action/changeling))
+				return FALSE
+			return changeling.purchase_power(ability_path)
+		if("readapt_standard")
+			return changeling.readapt()
+		if("commit_build")
+			var/datum/changeling_bio_incubator/build/build = changeling.find_genetic_matrix_build(params["build"])
+			if(!build)
+				return FALSE
+			return changeling.commit_genetic_matrix_build(build, user)
+	return FALSE
 
 /datum/action/changeling/genetic_matrix
 	name = "Genetic Matrix"


### PR DESCRIPTION
## Summary
- replace leading spaces with tabs in the changeling bio incubator definitions so DreamMaker accepts the file again
- convert the changeling antagonist and genetic matrix procs to use tab indentation and clean their block comments

## Testing
- not run (DreamMaker compiler unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d00481b3bc832aa8f35400b9e09b1c