### PR TITLE
Fix changeling indentation

### DIFF
--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -92,24 +92,24 @@
 	var/matrix_adrenal_spike_active = FALSE
 	/// Mob currently registered for predator's sinew hit hooks.
 	var/mob/living/matrix_predator_sinew_bound_mob
-        /// Timer tracking a pending adrenal spike shockwave.
-        var/matrix_adrenal_spike_shockwave_timer
-        /// Aggregated matrix effects currently applied to this changeling.
-        var/list/genetic_matrix_effect_cache = list()
-        /// Mob currently benefiting from passive matrix effect adjustments.
-        var/mob/living/matrix_passive_effects_bound_mob
-        /// Cached slowdown applied by passive matrix effects.
-        var/matrix_current_movespeed_slowdown = 0
-        /// Cached stamina usage multiplier from passive effects.
-        var/matrix_current_stamina_use_mult = 1
-        /// Cached stamina regeneration multiplier from passive effects.
-        var/matrix_current_stamina_regen_mult = 1
-        /// Cached max stamina bonus applied by passive effects.
-        var/matrix_current_max_stamina_bonus = 0
-        /// Cached chemical recharge modifier from passive effects.
-        var/matrix_current_chem_rate_bonus = 0
-        /// Cached sting range bonus from passive effects.
-        var/matrix_current_sting_range_bonus = 0
+	/// Timer tracking a pending adrenal spike shockwave.
+	var/matrix_adrenal_spike_shockwave_timer
+	/// Aggregated matrix effects currently applied to this changeling.
+	var/list/genetic_matrix_effect_cache = list()
+	/// Mob currently benefiting from passive matrix effect adjustments.
+	var/mob/living/matrix_passive_effects_bound_mob
+	/// Cached slowdown applied by passive matrix effects.
+	var/matrix_current_movespeed_slowdown = 0
+	/// Cached stamina usage multiplier from passive effects.
+	var/matrix_current_stamina_use_mult = 1
+	/// Cached stamina regeneration multiplier from passive effects.
+	var/matrix_current_stamina_regen_mult = 1
+	/// Cached max stamina bonus applied by passive effects.
+	var/matrix_current_max_stamina_bonus = 0
+	/// Cached chemical recharge modifier from passive effects.
+	var/matrix_current_chem_rate_bonus = 0
+	/// Cached sting range bonus from passive effects.
+	var/matrix_current_sting_range_bonus = 0
 
 	/// UI displaying how many chems we have
 	var/atom/movable/screen/ling/chems/lingchemdisplay
@@ -158,11 +158,11 @@
 		break
 
 /datum/antagonist/changeling/Destroy()
-        clear_matrix_passive_effects()
-        QDEL_NULL(emporium_action)
-        QDEL_NULL(cellular_emporium)
-        QDEL_NULL(genetic_matrix_action)
-        QDEL_NULL(genetic_matrix)
+	clear_matrix_passive_effects()
+	QDEL_NULL(emporium_action)
+	QDEL_NULL(cellular_emporium)
+	QDEL_NULL(genetic_matrix_action)
+	QDEL_NULL(genetic_matrix)
 	QDEL_NULL(bio_incubator)
 	current_profile = null
 	return ..()
@@ -373,10 +373,10 @@
 	update_matrix_predatory_howl("matrix_predatory_howl" in active_ids)
 	update_matrix_symbiotic_overgrowth("matrix_symbiotic_overgrowth" in active_ids)
 	update_matrix_feathered_veil_effect("matrix_feathered_veil" in active_ids)
-        update_matrix_predator_sinew_effect("matrix_predator_sinew" in active_ids)
-        update_matrix_void_carapace_effect("matrix_void_carapace" in active_ids)
-        update_matrix_adrenal_spike_effect("matrix_adrenal_spike" in active_ids)
-        update_matrix_passive_effects(active_ids)
+	update_matrix_predator_sinew_effect("matrix_predator_sinew" in active_ids)
+	update_matrix_void_carapace_effect("matrix_void_carapace" in active_ids)
+	update_matrix_adrenal_spike_effect("matrix_adrenal_spike" in active_ids)
+	update_matrix_passive_effects(active_ids)
 
 /datum/antagonist/changeling/proc/is_genetic_matrix_module_active(module_identifier)
 	if(isnull(module_identifier))
@@ -516,122 +516,122 @@
 	matrix_adrenal_spike_shockwave_timer = addtimer(CALLBACK(src, PROC_REF(adrenal_spike_shockwave), user), 2 SECONDS, TIMER_UNIQUE | TIMER_OVERRIDE)
 
 /datum/antagonist/changeling/proc/adrenal_spike_shockwave(mob/living/carbon/user)
-        matrix_adrenal_spike_shockwave_timer = null
-        if(!matrix_adrenal_spike_active || !istype(user) || user.stat == DEAD)
-                return
-        var/turf/user_turf = get_turf(user)
-        if(user_turf)
-                playsound(user_turf, 'sound/effects/bang.ogg', 50, TRUE)
-        user.visible_message(
-                span_warning("[user] releases a concussive chemical shockwave!"),
-                span_changeling("We vent a surge of volatile chemicals in a stunning wave."),
-        )
-        for(var/mob/living/nearby in oview(2, user))
-                if(nearby == user || nearby.stat == DEAD)
-                        continue
-                nearby.Knockdown(1.5 SECONDS)
-                nearby.adjustStaminaLoss(10)
+	matrix_adrenal_spike_shockwave_timer = null
+	if(!matrix_adrenal_spike_active || !istype(user) || user.stat == DEAD)
+		return
+	var/turf/user_turf = get_turf(user)
+	if(user_turf)
+		playsound(user_turf, 'sound/effects/bang.ogg', 50, TRUE)
+	user.visible_message(
+		span_warning("[user] releases a concussive chemical shockwave!"),
+		span_changeling("We vent a surge of volatile chemicals in a stunning wave."),
+	)
+	for(var/mob/living/nearby in oview(2, user))
+		if(nearby == user || nearby.stat == DEAD)
+			continue
+		nearby.Knockdown(1.5 SECONDS)
+		nearby.adjustStaminaLoss(10)
 
 /datum/antagonist/changeling/proc/clear_matrix_passive_effects()
-        if(matrix_passive_effects_bound_mob)
-                var/mob/living/living_owner = matrix_passive_effects_bound_mob
-                living_owner.remove_movespeed_modifier(/datum/movespeed_modifier/changeling/genetic_matrix)
-                var/datum/physiology/phys = living_owner.physiology
-                if(phys && matrix_current_stamina_use_mult != 1)
-                        phys.stamina_mod /= matrix_current_stamina_use_mult
-                if(matrix_current_stamina_regen_mult != 1)
-                        living_owner.stamina_regen_time /= matrix_current_stamina_regen_mult
-                if(matrix_current_max_stamina_bonus)
-                        living_owner.max_stamina -= matrix_current_max_stamina_bonus
-                        living_owner.staminaloss = clamp(living_owner.staminaloss, 0, living_owner.max_stamina)
-        if(matrix_current_chem_rate_bonus)
-                chem_recharge_rate -= matrix_current_chem_rate_bonus
-        if(matrix_current_sting_range_bonus)
-                sting_range -= matrix_current_sting_range_bonus
-        matrix_passive_effects_bound_mob = null
-        matrix_current_movespeed_slowdown = 0
-        matrix_current_stamina_use_mult = 1
-        matrix_current_stamina_regen_mult = 1
-        matrix_current_max_stamina_bonus = 0
-        matrix_current_chem_rate_bonus = 0
-        matrix_current_sting_range_bonus = 0
-        genetic_matrix_effect_cache = changeling_get_default_matrix_effects()
+	if(matrix_passive_effects_bound_mob)
+		var/mob/living/living_owner = matrix_passive_effects_bound_mob
+		living_owner.remove_movespeed_modifier(/datum/movespeed_modifier/changeling/genetic_matrix)
+		var/datum/physiology/phys = living_owner.physiology
+		if(phys && matrix_current_stamina_use_mult != 1)
+			phys.stamina_mod /= matrix_current_stamina_use_mult
+		if(matrix_current_stamina_regen_mult != 1)
+			living_owner.stamina_regen_time /= matrix_current_stamina_regen_mult
+		if(matrix_current_max_stamina_bonus)
+			living_owner.max_stamina -= matrix_current_max_stamina_bonus
+			living_owner.staminaloss = clamp(living_owner.staminaloss, 0, living_owner.max_stamina)
+	if(matrix_current_chem_rate_bonus)
+		chem_recharge_rate -= matrix_current_chem_rate_bonus
+	if(matrix_current_sting_range_bonus)
+		sting_range -= matrix_current_sting_range_bonus
+	matrix_passive_effects_bound_mob = null
+	matrix_current_movespeed_slowdown = 0
+	matrix_current_stamina_use_mult = 1
+	matrix_current_stamina_regen_mult = 1
+	matrix_current_max_stamina_bonus = 0
+	matrix_current_chem_rate_bonus = 0
+	matrix_current_sting_range_bonus = 0
+	genetic_matrix_effect_cache = changeling_get_default_matrix_effects()
 
 /datum/antagonist/changeling/proc/update_matrix_passive_effects(list/active_ids)
-        var/list/effect_totals = changeling_get_default_matrix_effects()
-        if(islist(active_ids))
-                for(var/module_id in active_ids)
-                        var/list/recipe = GLOB.changeling_genetic_matrix_recipes[module_id]
-                        if(!islist(recipe))
-                                continue
-                        var/list/module_data = recipe["module"]
-                        if(!islist(module_data))
-                                continue
-                        var/list/module_effects = module_data["effects"]
-                        if(!islist(module_effects))
-                                continue
-                        for(var/effect_key in module_effects)
-                                var/effect_value = module_effects[effect_key]
-                                if(isnull(effect_value))
-                                        continue
-                                if(isnum(effect_value))
-                                        if(effect_key in CHANGELING_MATRIX_MULTIPLICATIVE_EFFECT_KEYS)
-                                                effect_totals[effect_key] *= effect_value
-                                        else
-                                                effect_totals[effect_key] += effect_value
-                                else
-                                        effect_totals[effect_key] = effect_value
-        apply_matrix_passive_effect_totals(effect_totals)
+	var/list/effect_totals = changeling_get_default_matrix_effects()
+	if(islist(active_ids))
+		for(var/module_id in active_ids)
+			var/list/recipe = GLOB.changeling_genetic_matrix_recipes[module_id]
+			if(!islist(recipe))
+				continue
+			var/list/module_data = recipe["module"]
+			if(!islist(module_data))
+				continue
+			var/list/module_effects = module_data["effects"]
+			if(!islist(module_effects))
+				continue
+			for(var/effect_key in module_effects)
+				var/effect_value = module_effects[effect_key]
+				if(isnull(effect_value))
+					continue
+				if(isnum(effect_value))
+					if(effect_key in CHANGELING_MATRIX_MULTIPLICATIVE_EFFECT_KEYS)
+						effect_totals[effect_key] *= effect_value
+					else
+						effect_totals[effect_key] += effect_value
+				else
+					effect_totals[effect_key] = effect_value
+	apply_matrix_passive_effect_totals(effect_totals)
 
 /datum/antagonist/changeling/proc/apply_matrix_passive_effect_totals(list/totals)
-        clear_matrix_passive_effects()
-        if(!islist(totals))
-                totals = changeling_get_default_matrix_effects()
-        var/mob/living/living_owner = owner?.current
-        var/move_slowdown = totals["move_speed_slowdown"]
-        var/stamina_mult = totals["stamina_use_mult"]
-        var/regen_mult = totals["stamina_regen_time_mult"]
-        var/max_bonus = round(totals["max_stamina_add"])
-        var/chem_bonus = totals["chem_recharge_rate_add"]
-        var/sting_bonus = round(totals["sting_range_add"])
+	clear_matrix_passive_effects()
+	if(!islist(totals))
+		totals = changeling_get_default_matrix_effects()
+	var/mob/living/living_owner = owner?.current
+	var/move_slowdown = totals["move_speed_slowdown"]
+	var/stamina_mult = totals["stamina_use_mult"]
+	var/regen_mult = totals["stamina_regen_time_mult"]
+	var/max_bonus = round(totals["max_stamina_add"])
+	var/chem_bonus = totals["chem_recharge_rate_add"]
+	var/sting_bonus = round(totals["sting_range_add"])
 
-        matrix_current_movespeed_slowdown = move_slowdown
-        matrix_current_stamina_use_mult = stamina_mult
-        matrix_current_stamina_regen_mult = regen_mult
-        matrix_current_max_stamina_bonus = max_bonus
-        matrix_current_chem_rate_bonus = chem_bonus
-        matrix_current_sting_range_bonus = sting_bonus
+	matrix_current_movespeed_slowdown = move_slowdown
+	matrix_current_stamina_use_mult = stamina_mult
+	matrix_current_stamina_regen_mult = regen_mult
+	matrix_current_max_stamina_bonus = max_bonus
+	matrix_current_chem_rate_bonus = chem_bonus
+	matrix_current_sting_range_bonus = sting_bonus
 
-        if(chem_bonus)
-                chem_recharge_rate += chem_bonus
-        if(sting_bonus)
-                sting_range += sting_bonus
+	if(chem_bonus)
+		chem_recharge_rate += chem_bonus
+	if(sting_bonus)
+		sting_range += sting_bonus
 
-        genetic_matrix_effect_cache = totals.Copy()
+	genetic_matrix_effect_cache = totals.Copy()
 
-        if(!isliving(living_owner))
-                return
+	if(!isliving(living_owner))
+		return
 
-        matrix_passive_effects_bound_mob = living_owner
-        living_owner.remove_movespeed_modifier(/datum/movespeed_modifier/changeling/genetic_matrix)
-        if(move_slowdown)
-                living_owner.add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/changeling/genetic_matrix, TRUE, multiplicative_slowdown = move_slowdown)
-        var/datum/physiology/phys = living_owner.physiology
-        if(phys && stamina_mult != 1)
-                        phys.stamina_mod *= stamina_mult
-        if(regen_mult != 1)
-                living_owner.stamina_regen_time *= regen_mult
-        if(max_bonus)
-                living_owner.max_stamina += max_bonus
-                living_owner.staminaloss = clamp(living_owner.staminaloss, 0, living_owner.max_stamina)
+	matrix_passive_effects_bound_mob = living_owner
+	living_owner.remove_movespeed_modifier(/datum/movespeed_modifier/changeling/genetic_matrix)
+	if(move_slowdown)
+		living_owner.add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/changeling/genetic_matrix, TRUE, multiplicative_slowdown = move_slowdown)
+	var/datum/physiology/phys = living_owner.physiology
+	if(phys && stamina_mult != 1)
+			phys.stamina_mod *= stamina_mult
+	if(regen_mult != 1)
+		living_owner.stamina_regen_time *= regen_mult
+	if(max_bonus)
+		living_owner.max_stamina += max_bonus
+		living_owner.staminaloss = clamp(living_owner.staminaloss, 0, living_owner.max_stamina)
 
 /datum/antagonist/changeling/proc/get_genetic_matrix_effect(effect_key, default_value)
-        if(!islist(genetic_matrix_effect_cache))
-                return default_value
-        var/result = genetic_matrix_effect_cache[effect_key]
-        if(isnull(result))
-                return default_value
-        return result
+	if(!islist(genetic_matrix_effect_cache))
+		return default_value
+	var/result = genetic_matrix_effect_cache[effect_key]
+	if(isnull(result))
+		return default_value
+	return result
 /*
  * Instantiate all the default actions of a ling (transform, dna sting, absorb, etc)
  * Any Changeling action with dna_cost = CHANGELING_POWER_INNATE will be added here automatically

--- a/code/modules/antagonists/changeling/powers/biodegrade.dm
+++ b/code/modules/antagonists/changeling/powers/biodegrade.dm
@@ -1,52 +1,52 @@
 /datum/action/changeling/biodegrade
-        name = "Biodegrade"
-        desc = "Dissolves restraints or other objects preventing free movement. Costs 30 chemicals."
-        helptext = "This is obvious to nearby people, and can destroy standard restraints and closets."
-        button_icon_state = "biodegrade"
-        chemical_cost = 30 //High cost to prevent spam
-        dna_cost = 2
-        req_human = TRUE
-        disabled_by_fire = FALSE
+	name = "Biodegrade"
+	desc = "Dissolves restraints or other objects preventing free movement. Costs 30 chemicals."
+	helptext = "This is obvious to nearby people, and can destroy standard restraints and closets."
+	button_icon_state = "biodegrade"
+	chemical_cost = 30 //High cost to prevent spam
+	dna_cost = 2
+	req_human = TRUE
+	disabled_by_fire = FALSE
 
 /datum/action/changeling/biodegrade/proc/get_effective_cost(datum/antagonist/changeling/changeling)
-        if(!changeling)
-                return chemical_cost
-        var/discount = round(changeling.get_genetic_matrix_effect("biodegrade_chem_discount", 0))
-        return max(0, chemical_cost - discount)
+	if(!changeling)
+		return chemical_cost
+	var/discount = round(changeling.get_genetic_matrix_effect("biodegrade_chem_discount", 0))
+	return max(0, chemical_cost - discount)
 
 /datum/action/changeling/biodegrade/proc/get_effective_delay(datum/antagonist/changeling/changeling, delay)
-        var/multiplier = changeling?.get_genetic_matrix_effect("biodegrade_timer_mult", 1) || 1
-        if(multiplier < 0)
-                multiplier = 0
-        var/result = round(delay * multiplier)
-        return max(1, result)
+	var/multiplier = changeling?.get_genetic_matrix_effect("biodegrade_timer_mult", 1) || 1
+	if(multiplier < 0)
+		multiplier = 0
+	var/result = round(delay * multiplier)
+	return max(1, result)
 
 /datum/action/changeling/biodegrade/can_sting(mob/living/user, mob/living/target)
-        var/datum/antagonist/changeling/changeling = IS_CHANGELING(user)
-        var/old_cost = chemical_cost
-        chemical_cost = get_effective_cost(changeling)
-        var/result = ..()
-        chemical_cost = old_cost
-        return result
+	var/datum/antagonist/changeling/changeling = IS_CHANGELING(user)
+	var/old_cost = chemical_cost
+	chemical_cost = get_effective_cost(changeling)
+	var/result = ..()
+	chemical_cost = old_cost
+	return result
 
 /datum/action/changeling/biodegrade/try_to_sting(mob/living/user, mob/living/target)
-        var/datum/antagonist/changeling/changeling = IS_CHANGELING(user)
-        var/old_cost = chemical_cost
-        chemical_cost = get_effective_cost(changeling)
-        var/result = ..()
-        chemical_cost = old_cost
-        return result
+	var/datum/antagonist/changeling/changeling = IS_CHANGELING(user)
+	var/old_cost = chemical_cost
+	chemical_cost = get_effective_cost(changeling)
+	var/result = ..()
+	chemical_cost = old_cost
+	return result
 
 /datum/action/changeling/biodegrade/sting_action(mob/living/carbon/human/user)
-        var/datum/antagonist/changeling/changeling = IS_CHANGELING(user)
-        if(user.handcuffed)
+	var/datum/antagonist/changeling/changeling = IS_CHANGELING(user)
+	if(user.handcuffed)
 		var/obj/O = user.get_item_by_slot(ITEM_SLOT_HANDCUFFED)
 		if(!istype(O))
 			return FALSE
 		user.visible_message(span_warning("[user] vomits a glob of acid on [user.p_their()] [O]!"), \
 			span_warning("We vomit acidic ooze onto our restraints!"))
 
-                addtimer(CALLBACK(src, PROC_REF(dissolve_handcuffs), user, O), get_effective_delay(changeling, 3 SECONDS))
+		addtimer(CALLBACK(src, PROC_REF(dissolve_handcuffs), user, O), get_effective_delay(changeling, 3 SECONDS))
 		log_combat(user, user.handcuffed, "melted handcuffs", addition = "(biodegrade)")
 		..()
 		return TRUE
@@ -58,7 +58,7 @@
 		user.visible_message(span_warning("[user] vomits a glob of acid on [user.p_their()] [O]!"), \
 			span_warning("We vomit acidic ooze onto our restraints!"))
 
-                addtimer(CALLBACK(src, PROC_REF(dissolve_legcuffs), user, O), get_effective_delay(changeling, 3 SECONDS))
+		addtimer(CALLBACK(src, PROC_REF(dissolve_legcuffs), user, O), get_effective_delay(changeling, 3 SECONDS))
 		log_combat(user, user.legcuffed, "melted legcuffs", addition = "(biodegrade)")
 		..()
 		return TRUE
@@ -69,7 +69,7 @@
 			return FALSE
 		user.visible_message(span_warning("[user] vomits a glob of acid across the front of [user.p_their()] [S]!"), \
 			span_warning("We vomit acidic ooze onto our [user.wear_suit.name]!"))
-                addtimer(CALLBACK(src, PROC_REF(dissolve_straightjacket), user, S), get_effective_delay(changeling, 3 SECONDS))
+		addtimer(CALLBACK(src, PROC_REF(dissolve_straightjacket), user, S), get_effective_delay(changeling, 3 SECONDS))
 		log_combat(user, user.wear_suit, "melted [user.wear_suit]", addition = "(biodegrade)")
 		..()
 		return TRUE
@@ -80,7 +80,7 @@
 			return FALSE
 		C.visible_message(span_warning("[C]'s hinges suddenly begin to melt and run!"))
 		to_chat(user, span_warning("We vomit acidic goop onto the interior of [C]!"))
-                addtimer(CALLBACK(src, PROC_REF(open_closet), user, C), get_effective_delay(changeling, 7 SECONDS))
+		addtimer(CALLBACK(src, PROC_REF(open_closet), user, C), get_effective_delay(changeling, 7 SECONDS))
 		log_combat(user, user.loc, "melted locker", addition = "(biodegrade)")
 		..()
 		return TRUE
@@ -91,7 +91,7 @@
 			return FALSE
 		C.visible_message(span_warning("[src] shifts and starts to fall apart!"))
 		to_chat(user, span_warning("We secrete acidic enzymes from our skin and begin melting our cocoon..."))
-                addtimer(CALLBACK(src, PROC_REF(dissolve_cocoon), user, C), get_effective_delay(changeling, 25)) //Very short because it's just webs
+		addtimer(CALLBACK(src, PROC_REF(dissolve_cocoon), user, C), get_effective_delay(changeling, 25)) //Very short because it's just webs
 		log_combat(user, user.loc, "melted cocoon", addition = "(biodegrade)")
 		..()
 		return TRUE

--- a/code/modules/antagonists/changeling/powers/harvest_cells.dm
+++ b/code/modules/antagonists/changeling/powers/harvest_cells.dm
@@ -1,86 +1,86 @@
 /datum/action/changeling/sting/harvest_cells
-        name = "Harvest Cells"
-        desc = "We silently pierce a victim to obtain adaptable cell signatures."
-        helptext = "Collects a compatible cell entry from living station species or barnyard animals without alerting witnesses."
-        button_icon_state = "sting_extract"
-        chemical_cost = 10
-        dna_cost = CHANGELING_POWER_INNATE
-        allow_nonliving_targets = TRUE
+	name = "Harvest Cells"
+	desc = "We silently pierce a victim to obtain adaptable cell signatures."
+	helptext = "Collects a compatible cell entry from living station species or barnyard animals without alerting witnesses."
+	button_icon_state = "sting_extract"
+	chemical_cost = 10
+	dna_cost = CHANGELING_POWER_INNATE
+	allow_nonliving_targets = TRUE
 
 /datum/action/changeling/sting/harvest_cells/proc/get_effective_cost(datum/antagonist/changeling/changeling)
-        if(!changeling)
-                return chemical_cost
-        var/discount = round(changeling.get_genetic_matrix_effect("harvest_cells_chem_discount", 0))
-        return max(0, chemical_cost - discount)
+	if(!changeling)
+		return chemical_cost
+	var/discount = round(changeling.get_genetic_matrix_effect("harvest_cells_chem_discount", 0))
+	return max(0, chemical_cost - discount)
 
 /datum/action/changeling/sting/harvest_cells/proc/get_effective_range(datum/antagonist/changeling/changeling)
-        var/base_range = changeling?.sting_range || 0
-        var/bonus = round(changeling?.get_genetic_matrix_effect("harvest_cells_bonus_range", 0))
-        return max(0, base_range + bonus)
+	var/base_range = changeling?.sting_range || 0
+	var/bonus = round(changeling?.get_genetic_matrix_effect("harvest_cells_bonus_range", 0))
+	return max(0, base_range + bonus)
 
 /datum/action/changeling/sting/harvest_cells/can_sting(mob/living/user, mob/living/target)
-        if(!can_use_harvest(user))
-                return FALSE
-        if(!target)
-                return FALSE
-        if(!isturf(user.loc))
-                return FALSE
-        var/datum/antagonist/changeling/changeling = IS_CHANGELING(user)
-        if(target.mob_biotypes & MOB_ROBOTIC)
-                user.balloon_alert(user, "no organic cells!")
-                return FALSE
-        if(!reachable_target(user, target, get_effective_range(changeling)))
-                return FALSE
-        var/list/cell_ids = collect_cell_ids(target)
-        if(!cell_ids.len)
-                user.balloon_alert(user, "no viable cells!")
-                return FALSE
-        return TRUE
+	if(!can_use_harvest(user))
+		return FALSE
+	if(!target)
+		return FALSE
+	if(!isturf(user.loc))
+		return FALSE
+	var/datum/antagonist/changeling/changeling = IS_CHANGELING(user)
+	if(target.mob_biotypes & MOB_ROBOTIC)
+		user.balloon_alert(user, "no organic cells!")
+		return FALSE
+	if(!reachable_target(user, target, get_effective_range(changeling)))
+		return FALSE
+	var/list/cell_ids = collect_cell_ids(target)
+	if(!cell_ids.len)
+		user.balloon_alert(user, "no viable cells!")
+		return FALSE
+	return TRUE
 
 /datum/action/changeling/sting/harvest_cells/try_to_sting_nonliving(mob/living/user, atom/target)
-        if(!can_harvest_nonliving(user, target))
-                return FALSE
-        if(disabled_by_fire && user.fire_stacks && user.on_fire)
-                user.balloon_alert(user, "on fire!")
-                return FALSE
-        var/datum/antagonist/changeling/changeling = IS_CHANGELING(user)
-        if(!perform_harvest(user, target))
-                return FALSE
-        changeling?.adjust_chemicals(-get_effective_cost(changeling))
-        user.changeNext_move(CLICK_CD_MELEE)
-        return TRUE
+	if(!can_harvest_nonliving(user, target))
+		return FALSE
+	if(disabled_by_fire && user.fire_stacks && user.on_fire)
+		user.balloon_alert(user, "on fire!")
+		return FALSE
+	var/datum/antagonist/changeling/changeling = IS_CHANGELING(user)
+	if(!perform_harvest(user, target))
+		return FALSE
+	changeling?.adjust_chemicals(-get_effective_cost(changeling))
+	user.changeNext_move(CLICK_CD_MELEE)
+	return TRUE
 
 /datum/action/changeling/sting/harvest_cells/try_to_sting(mob/living/user, mob/living/target)
-        var/datum/antagonist/changeling/changeling = IS_CHANGELING(user)
-        var/old_cost = chemical_cost
-        chemical_cost = get_effective_cost(changeling)
-        var/result = ..()
-        chemical_cost = old_cost
-        return result
+	var/datum/antagonist/changeling/changeling = IS_CHANGELING(user)
+	var/old_cost = chemical_cost
+	chemical_cost = get_effective_cost(changeling)
+	var/result = ..()
+	chemical_cost = old_cost
+	return result
 
 /datum/action/changeling/sting/harvest_cells/sting_action(mob/living/user, mob/living/target)
-        if(!perform_harvest(user, target))
-                return FALSE
-        ..()
-        return TRUE
+	if(!perform_harvest(user, target))
+		return FALSE
+	..()
+	return TRUE
 
 /datum/action/changeling/sting/harvest_cells/sting_feedback(mob/living/user, mob/living/target)
 	return TRUE
 
 /datum/action/changeling/sting/harvest_cells/proc/can_harvest_nonliving(mob/living/user, atom/target)
-        if(!target)
-                return FALSE
-        if(!can_use_harvest(user))
-                return FALSE
-        if(!isturf(user.loc))
-                return FALSE
-        var/datum/antagonist/changeling/changeling = IS_CHANGELING(user)
-        if(!reachable_target(user, target, get_effective_range(changeling)))
-                return FALSE
-        var/list/cell_ids = collect_cell_ids(target)
-        if(!cell_ids.len)
-                user.balloon_alert(user, "no viable cells!")
-                return FALSE
+	if(!target)
+		return FALSE
+	if(!can_use_harvest(user))
+		return FALSE
+	if(!isturf(user.loc))
+		return FALSE
+	var/datum/antagonist/changeling/changeling = IS_CHANGELING(user)
+	if(!reachable_target(user, target, get_effective_range(changeling)))
+		return FALSE
+	var/list/cell_ids = collect_cell_ids(target)
+	if(!cell_ids.len)
+		user.balloon_alert(user, "no viable cells!")
+		return FALSE
 	return TRUE
 
 /datum/action/changeling/sting/harvest_cells/proc/reachable_target(mob/living/user, atom/target, range)
@@ -161,10 +161,10 @@
 			ids += cell_id
 	return ids
 /datum/action/changeling/sting/harvest_cells/proc/can_use_harvest(mob/living/user)
-        if(!can_be_used_by(user))
-                return FALSE
-        var/datum/antagonist/changeling/changeling = IS_CHANGELING(user)
-        if(!changeling)
+	if(!can_be_used_by(user))
+		return FALSE
+	var/datum/antagonist/changeling/changeling = IS_CHANGELING(user)
+	if(!changeling)
 		return FALSE
 	if(!changeling.chosen_sting)
 		to_chat(user, span_warning("We must prepare our sting before harvesting."))
@@ -172,10 +172,10 @@
 	if(changeling.chosen_sting != src)
 		to_chat(user, span_warning("We have primed a different sting."))
 		return FALSE
-        var/effective_cost = get_effective_cost(changeling)
-        if(changeling.chem_charges < effective_cost)
-                user.balloon_alert(user, "needs [effective_cost] chemicals!")
-                return FALSE
+	var/effective_cost = get_effective_cost(changeling)
+	if(changeling.chem_charges < effective_cost)
+		user.balloon_alert(user, "needs [effective_cost] chemicals!")
+		return FALSE
 	if(changeling.absorbed_count < req_dna)
 		user.balloon_alert(user, "needs [req_dna] dna sample\s!")
 		return FALSE


### PR DESCRIPTION
## Summary
- replace the space-indented changeling datum definitions with tab indentation so DreamMaker parses them correctly
- normalize indentation for the changeling Biodegrade action
- normalize indentation for the changeling Harvest Cells sting

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d02cf5c764832ab72781634b67b463