### PR TITLE
Fix changeling memory fragment quoting

### DIFF
--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -853,7 +853,7 @@
 	if(LAZYLEN(speech))
 		messages += span_notice("Snatches of speech linger:")
 	for(var/sample in speech)
-		messages += span_notice(""[sample]"")
+		messages += span_notice("\"[sample]\"")
 	for(var/message in messages)
 		to_chat(target, message)
 	playsound(target, 'sound/magic/mindswap.ogg', 50, TRUE)


### PR DESCRIPTION
## Summary
- correct the formatting of shared memory speech samples to include surrounding quotes without breaking compilation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d12185eb68832a8d26fe864570d1fd