### PR TITLE
Fix changeling assets and knockdown calls

### DIFF
--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -856,7 +856,7 @@
 		messages += span_notice("\"[sample]\"")
 	for(var/message in messages)
 		to_chat(target, message)
-	playsound(target, 'sound/magic/mindswap.ogg', 50, TRUE)
+       playsound(target, 'sound/effects/magic/magic_block_mind.ogg', 50, TRUE)
 	return TRUE
 
 /datum/antagonist/changeling/proc/apply_neuro_sap_bonus()

--- a/code/modules/antagonists/changeling/powers/aether_burst.dm
+++ b/code/modules/antagonists/changeling/powers/aether_burst.dm
@@ -35,7 +35,7 @@
 		return FALSE
 	if(user.throw_at(target, range = 4, speed = 2, thrower = user, gentle = TRUE))
 		next_allowed = world.time + cooldown_length
-		playsound(user, 'sound/magic/wandteleport.ogg', 50, TRUE)
+               playsound(user, 'sound/effects/magic/wand_teleport.ogg', 50, TRUE)
 		user.visible_message(
 			span_warning("[user] rockets forward in a streak of violet plasma!"),
 			span_changeling("We vent a burst of voidfire to surge ahead."),

--- a/code/modules/antagonists/changeling/powers/chorus_stasis.dm
+++ b/code/modules/antagonists/changeling/powers/chorus_stasis.dm
@@ -19,7 +19,7 @@
 /obj/structure/changeling_chorus_cocoon
 	name = "chorus cocoon"
 	desc = "A resonant changeling pod humming with muffled voices."
-	icon = 'icons/obj/structures/spider.dmi'
+       icon = 'modular_nova/modules/spider/icons/spider.dmi'
 	icon_state = "cocoon"
 	anchored = TRUE
 	density = FALSE
@@ -70,19 +70,19 @@
 	return TRUE
 
 /obj/structure/changeling_chorus_cocoon/proc/detonate(mob/living/user)
-	playsound(src, 'sound/magic/clockwork/anima_fragment_charge.ogg', 60, TRUE)
+       playsound(src, 'sound/effects/magic/clockwork/anima_fragment_attack.ogg', 60, TRUE)
 	visible_message(
 		span_danger("[src] ruptures in a wave of soporific gas!"),
 		span_notice("We unravel the cocoon, flooding the area with muting spores."),
 	)
 	for(var/mob/living/occupant in buckled_mobs.Copy())
 		unbuckle_mob(occupant, force = TRUE, can_fall = FALSE)
-		occupant.Weaken(1)
+               occupant.Knockdown(1 SECONDS)
 	for(var/mob/living/target in range(2, src))
 		if(target.stat == DEAD || IS_CHANGELING(target))
 			continue
-		target.adjustStaminaLoss(25)
-		target.Weaken(2)
+               target.adjustStaminaLoss(25)
+               target.Knockdown(2 SECONDS)
 		target.adjust_confusion(30)
 	qdel(src)
 	var/datum/antagonist/changeling/changeling_data = changeling_ref?.resolve()

--- a/code/modules/antagonists/changeling/powers/spore_node.dm
+++ b/code/modules/antagonists/changeling/powers/spore_node.dm
@@ -26,7 +26,7 @@
 /obj/structure/changeling_spore_node
 	name = "spore node"
 	desc = "A pulsating changeling beacon that hums with pheromonal static."
-	icon = 'icons/obj/structures/spider.dmi'
+       icon = 'modular_nova/modules/spider/icons/spider.dmi'
 	icon_state = "egg"
 	anchored = TRUE
 	density = FALSE
@@ -79,7 +79,7 @@
 	to_chat(owner, span_changeling("Our spore node senses movement near [victim]."))
 
 /obj/structure/changeling_spore_node/proc/detonate(mob/living/user)
-	playsound(src, 'sound/magic/disable.ogg', 60, TRUE)
+       playsound(src, 'sound/effects/magic/disable_tech.ogg', 60, TRUE)
 	visible_message(
 		span_danger("[src] ruptures into a haze of grasping spores!"),
 		span_notice("Our spores rupture into a slowing miasma."),
@@ -87,8 +87,8 @@
 	for(var/mob/living/target in range(2, src))
 		if(target.stat == DEAD || IS_CHANGELING(target))
 			continue
-		target.adjustStaminaLoss(20)
-		target.Weaken(1)
+               target.adjustStaminaLoss(20)
+               target.Knockdown(1 SECONDS)
 		target.apply_status_effect(/datum/status_effect/dazed, 3 SECONDS)
 	qdel(src)
 	var/datum/antagonist/changeling/changeling_data = changeling_ref?.resolve()


### PR DESCRIPTION
## Summary
- point changeling ability sound references replaced with existing magic sound assets
- point update changeling structures to use available spider icon and modern knockdown proc instead of removed Weaken

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d124b6eb3c832a8199640b51a3f092