### PR TITLE
Localize changeling matrix multiplier list

### DIFF
--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -1263,6 +1263,15 @@
 	genetic_matrix_effect_cache = changeling_get_default_matrix_effects()
 
 /datum/antagonist/changeling/proc/update_matrix_passive_effects(list/active_ids)
+	var/static/list/multiplicative_effect_keys = list(
+		"stamina_use_mult",
+		"stamina_regen_time_mult",
+		"fleshmend_heal_mult",
+		"biodegrade_timer_mult",
+		"feathered_veil_cooldown_mult",
+		"resonant_shriek_confusion_mult",
+		"dissonant_shriek_structure_mult",
+	)
 	var/list/effect_totals = changeling_get_default_matrix_effects()
 	if(islist(active_ids))
 		for(var/module_id in active_ids)
@@ -1280,7 +1289,7 @@
 				if(isnull(effect_value))
 					continue
 				if(isnum(effect_value))
-					if(effect_key in CHANGELING_MATRIX_MULTIPLICATIVE_EFFECT_KEYS)
+					if(effect_key in multiplicative_effect_keys)
 						effect_totals[effect_key] *= effect_value
 					else
 						effect_totals[effect_key] += effect_value

--- a/code/modules/antagonists/changeling/genetic_matrix_content.dm
+++ b/code/modules/antagonists/changeling/genetic_matrix_content.dm
@@ -2,16 +2,6 @@
 #define GENETIC_MATRIX_CATEGORY_PASSIVE "passive"
 #define GENETIC_MATRIX_CATEGORY_UPGRADE "upgrade"
 
-#define CHANGELING_MATRIX_MULTIPLICATIVE_EFFECT_KEYS list(\
-        "stamina_use_mult",\
-        "stamina_regen_time_mult",\
-        "fleshmend_heal_mult",\
-        "biodegrade_timer_mult",\
-        "feathered_veil_cooldown_mult",\
-        "resonant_shriek_confusion_mult",\
-        "dissonant_shriek_structure_mult"\
-)
-
 GLOBAL_LIST_INIT(changeling_genetic_matrix_recipes, setup_changeling_genetic_matrix_recipes())
 
 /// Movespeed modifier used for genetic matrix passive bonuses.


### PR DESCRIPTION
## Summary
- remove the changeling matrix multiplier list from the genetic matrix content definitions
- define the multiplier keys locally in `update_matrix_passive_effects` so the proc no longer depends on another file

## Testing
- python tools/validate_dme.py < tgstation.dme

------
https://chatgpt.com/codex/tasks/task_e_68d17ad66014832a94ed1950917ecb3b