### PR TITLE
Adjust changeling stasis and effects

### DIFF
--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -1182,7 +1182,7 @@
 	if(!istype(location) || location.is_blocked_turf(TRUE, source_atom = user))
 		user.balloon_alert(user, "bad turf")
 		return FALSE
-	var/mob/living/chorus_target = (istype(target) && target != user) ? target : null
+        var/mob/living/chorus_target = (istype(target) && target != user) ? target : null
 	if(!do_after(user, 4 SECONDS, target = location, extra_checks = CALLBACK(src, PROC_REF(can_continue_chorus_stasis), user, location)))
 		return FALSE
 	if(!matrix_chorus_stasis_active || !istype(user))
@@ -1193,20 +1193,25 @@
 	if(!istype(location) || location.is_blocked_turf(TRUE, source_atom = user))
 		user.balloon_alert(user, "bad turf")
 		return FALSE
-	if(chorus_target && (QDELETED(chorus_target) || !user.Adjacent(chorus_target)))
-		chorus_target = null
-	var/obj/structure/changeling_chorus_cocoon/cocoon = new(location, src)
-	if(!cocoon.add_occupant(user))
-		qdel(cocoon)
-		return FALSE
-	matrix_chorus_cocoon_ref = WEAKREF(cocoon)
-	if(chorus_target)
-		cocoon.add_occupant(chorus_target)
-	user.visible_message(
-		span_warning("[user] weaves a muffled cocoon of tendrils!"),
-		span_changeling("We spin a chorus cocoon to hide and recover."),
-	)
-	return TRUE
+        if(chorus_target && (QDELETED(chorus_target) || !user.Adjacent(chorus_target)))
+                chorus_target = null
+        var/mob/living/occupant = chorus_target || user
+        var/obj/structure/changeling_chorus_cocoon/cocoon = new(location, src)
+        if(!cocoon.add_occupant(occupant))
+                qdel(cocoon)
+                return FALSE
+        matrix_chorus_cocoon_ref = WEAKREF(cocoon)
+        if(occupant == user)
+                user.visible_message(
+                        span_warning("[user] weaves a muffled cocoon of tendrils around [user.p_them()]self!"),
+                        span_changeling("We spin a chorus cocoon to hide and recover."),
+                )
+        else
+                user.visible_message(
+                        span_warning("[user] lashes [occupant] into a muffled cocoon of tendrils!"),
+                        span_changeling("We bind [occupant] within a chorus cocoon."),
+                )
+        return TRUE
 
 /datum/antagonist/changeling/proc/can_continue_chorus_stasis(mob/living/user, turf/original_location)
 	if(QDELETED(user) || !matrix_chorus_stasis_active)

--- a/code/modules/antagonists/changeling/passives/ashen_pump.dm
+++ b/code/modules/antagonists/changeling/passives/ashen_pump.dm
@@ -28,20 +28,18 @@
 	duration = 10 SECONDS
 	tick_interval = 0.5 SECONDS
 	alert_type = null
-	var/datum/weakref/changeling_ref
-	var/last_turf
-	var/applied_bonus = FALSE
+        var/datum/weakref/changeling_ref
+        var/applied_bonus = FALSE
 
 /datum/status_effect/changeling_ashen_pump/on_creation(mob/living/new_owner, datum/antagonist/changeling/changeling_data)
 	changeling_ref = WEAKREF(changeling_data)
 	return ..()
 
 /datum/status_effect/changeling_ashen_pump/on_apply()
-	RegisterSignal(owner, COMSIG_MOVABLE_MOVED, PROC_REF(on_owner_moved))
-	apply_burn_bonus()
-	create_flare(get_turf(owner))
-	last_turf = get_turf(owner)
-	return TRUE
+        RegisterSignal(owner, COMSIG_MOVABLE_MOVED, PROC_REF(on_owner_moved))
+        apply_burn_bonus()
+        create_flare(get_turf(owner))
+        return TRUE
 
 /datum/status_effect/changeling_ashen_pump/on_remove()
 	UnregisterSignal(owner, COMSIG_MOVABLE_MOVED)
@@ -52,16 +50,26 @@
 	create_flare(get_turf(owner))
 
 /datum/status_effect/changeling_ashen_pump/proc/on_owner_moved(atom/movable/source, atom/old_loc, move_dir, forced, list/atom/old_locs)
-	SIGNAL_HANDLER
-	create_flare(old_loc)
-	last_turf = get_turf(owner)
+        SIGNAL_HANDLER
+        create_flare(old_loc)
 
 /datum/status_effect/changeling_ashen_pump/proc/create_flare(atom/location)
-	if(!isturf(location))
-		return
-	var/turf/T = location
-	new /obj/effect/temp_visual/dir_setting/firing_effect/red(T, owner.dir)
-	T.hotspot_expose(600, 10)
+        if(!owner || !isturf(location))
+                return
+        var/turf/open/T = get_turf(location)
+        if(!istype(T))
+                return
+        new /obj/effect/temp_visual/changeling_ashen_flare(T)
+        if(!(locate(/obj/effect/hotspot) in T))
+                new /obj/effect/hotspot(T)
+        T.hotspot_expose(900, 50, 1)
+        if(owner in T)
+                owner.extinguish_mob()
+        for(var/mob/living/carbon/victim in T)
+                if(victim == owner || IS_CHANGELING(victim))
+                        continue
+                victim.adjust_fire_stacks(0.5)
+                victim.ignite_mob()
 
 /datum/status_effect/changeling_ashen_pump/proc/apply_burn_bonus()
 	if(applied_bonus)
@@ -74,11 +82,25 @@
 			applied_bonus = TRUE
 
 /datum/status_effect/changeling_ashen_pump/proc/remove_burn_bonus()
-	if(!applied_bonus)
-		return
-	if(ishuman(owner))
-		var/mob/living/carbon/human/H = owner
-		var/datum/physiology/phys = H.physiology
-		if(phys)
-			phys.burn_mod /= 0.5
-	applied_bonus = FALSE
+        if(!applied_bonus)
+                return
+        if(ishuman(owner))
+                var/mob/living/carbon/human/H = owner
+                var/datum/physiology/phys = H.physiology
+                if(phys)
+                        phys.burn_mod /= 0.5
+        applied_bonus = FALSE
+
+/obj/effect/temp_visual/changeling_ashen_flare
+        name = "ashen flare"
+        icon = 'icons/effects/fire.dmi'
+        icon_state = "heavy"
+        duration = 0.8 SECONDS
+        light_range = 2
+        light_color = LIGHT_COLOR_FIRE
+        randomdir = FALSE
+
+/obj/effect/temp_visual/changeling_ashen_flare/Initialize(mapload)
+        . = ..()
+        color = "#ffb347"
+        animate(src, alpha = 0, time = duration, easing = EASE_OUT)

--- a/code/modules/antagonists/changeling/passives/chorus_stasis.dm
+++ b/code/modules/antagonists/changeling/passives/chorus_stasis.dm
@@ -1,14 +1,14 @@
 
-/// Key Active: Chorus Stasis — weaves a two-body cocoon that heals, conceals, and can erupt into soporific gas.
+/// Key Active: Chorus Stasis — weaves a single-body cocoon that heals, conceals, and can erupt into soporific gas.
 /datum/changeling_genetic_matrix_recipe/chorus_stasis
 	id = "matrix_chorus_stasis"
 	name = "Chorus Stasis"
-	description = "Spin a cooperative cocoon to hide allies or prey before detonating them in chemical fog."
+        description = "Spin a solitary cocoon to hide yourself or one victim before detonating it in chemical fog."
 	module = list(
 			"id" = "matrix_chorus_stasis",
 			"name" = "Chorus Stasis",
-			"desc" = "Encase up to two bodies in a stasis cocoon that heals quietly and can burst into disorienting gas.",
-			"helptext" = "Activate to create or add to a cocoon; reuse while a cocoon exists to detonate it.",
+                        "desc" = "Encase one body in a stasis cocoon that quietly heals and can burst into disorienting gas.",
+                        "helptext" = "Activate to cocoon yourself or an adjacent creature; reuse while it exists to detonate it.",
 			"category" = GENETIC_MATRIX_CATEGORY_KEY,
 			"slotType" = BIO_INCUBATOR_SLOT_KEY,
 			"tags" = list("healing", "control"),

--- a/code/modules/antagonists/changeling/passives/hemolytic_bloom.dm
+++ b/code/modules/antagonists/changeling/passives/hemolytic_bloom.dm
@@ -22,32 +22,47 @@
 	)
 
 /obj/effect/temp_visual/changeling_hemolytic_seed
-	name = "hemolytic bloom"
-	icon = 'icons/effects/blood.dmi'
-	icon_state = "splatter1"
-	layer = ABOVE_MOB_LAYER
-	plane = GAME_PLANE
-	duration = 4 SECONDS
-	var/datum/weakref/changeling_ref
+        name = "hemolytic bloom"
+        icon = 'icons/effects/blood.dmi'
+        icon_state = "splatter1"
+        layer = ABOVE_MOB_LAYER
+        plane = GAME_PLANE
+        duration = 4 SECONDS
+        light_range = 1.5
+        light_color = "#8bff9a"
+        var/datum/weakref/changeling_ref
 
 /obj/effect/temp_visual/changeling_hemolytic_seed/Initialize(mapload, mob/living/victim, datum/antagonist/changeling/changeling_data)
-	. = ..()
-	changeling_ref = WEAKREF(changeling_data)
-	addtimer(CALLBACK(src, PROC_REF(burst)), 2 SECONDS)
-	return .
+        . = ..()
+        changeling_ref = WEAKREF(changeling_data)
+        color = "#9bff8c"
+        alpha = 220
+        animate(src, alpha = 90, time = 1 SECONDS, easing = EASE_OUT)
+        addtimer(CALLBACK(src, PROC_REF(burst)), 2 SECONDS)
+        return .
 
 /obj/effect/temp_visual/changeling_hemolytic_seed/proc/burst()
-	if(QDELETED(src))
-		return
-	visible_message(
-		span_danger("[src] ruptures into a spray of acidic spores!"),
-		span_notice("Our bloom erupts, digesting fresh biomass."),
-	)
-	for(var/mob/living/target in range(1, src))
-		if(IS_CHANGELING(target))
-			continue
-		target.adjustToxLoss(12)
-		target.apply_status_effect(/datum/status_effect/dazed, 4 SECONDS)
+        if(QDELETED(src))
+                return
+        playsound(src, 'sound/effects/splat.ogg', 55, TRUE)
+        visible_message(
+                span_danger("[src] ruptures into a spray of acidic spores!"),
+                span_notice("Our bloom erupts, digesting fresh biomass."),
+        )
+        var/turf/location = get_turf(src)
+        if(istype(location))
+                var/obj/effect/temp_visual/blob/eruption = new(location)
+                eruption.color = "#84ff9f"
+                eruption.alpha = 200
+                for(var/dir in GLOB.cardinals)
+                        new /obj/effect/temp_visual/dir_setting/bloodsplatter(location, dir, "#6bff9f")
+                var/obj/effect/temp_visual/small_smoke/halfsecond/mist = new(location)
+                mist.color = "#7fffb2"
+        for(var/mob/living/target in range(1, src))
+                if(IS_CHANGELING(target))
+                        continue
+                target.adjustToxLoss(12)
+                target.apply_status_effect(/datum/status_effect/dazed, 4 SECONDS)
 	var/datum/antagonist/changeling/changeling_data = changeling_ref?.resolve()
 	changeling_data?.adjust_chemicals(4)
 	qdel(src)

--- a/code/modules/antagonists/changeling/powers/chorus_stasis.dm
+++ b/code/modules/antagonists/changeling/powers/chorus_stasis.dm
@@ -1,91 +1,137 @@
 
 /datum/action/changeling/chorus_stasis
-	name = "Chorus Stasis"
-	desc = "Spin a cocoon around ourselves and a victim or ally, healing quietly until detonated. Costs 18 chemicals."
-	helptext = "Requires the Chorus Stasis key. Target an adjacent mob to pull them inside; reusing detonates the cocoon."
-	button_icon_state = "fake_death"
-	chemical_cost = 18
-	dna_cost = CHANGELING_POWER_UNOBTAINABLE
-	req_stat = CONSCIOUS
-	disabled_by_fire = FALSE
+        name = "Chorus Stasis"
+        desc = "Spin a cocoon around ourselves or one adjacent creature, healing quietly until detonated. Costs 18 chemicals."
+        helptext = "Requires the Chorus Stasis key. Target an adjacent mob to cocoon them instead; reusing detonates the cocoon."
+        button_icon_state = "fake_death"
+        chemical_cost = 18
+        dna_cost = CHANGELING_POWER_UNOBTAINABLE
+        req_stat = CONSCIOUS
+        disabled_by_fire = FALSE
 
 /datum/action/changeling/chorus_stasis/sting_action(mob/living/user, mob/living/target)
-	var/datum/antagonist/changeling/changeling_data = IS_CHANGELING(user)
-	if(!changeling_data?.matrix_chorus_stasis_active)
-		user.balloon_alert(user, "needs chorus key")
-		return FALSE
-	return changeling_data.handle_chorus_stasis_activation(user, target)
+        var/datum/antagonist/changeling/changeling_data = IS_CHANGELING(user)
+        if(!changeling_data?.matrix_chorus_stasis_active)
+                user.balloon_alert(user, "needs chorus key")
+                return FALSE
+        return changeling_data.handle_chorus_stasis_activation(user, target)
+
+/datum/status_effect/changeling_chorus_stasis
+        id = "changeling_chorus_stasis"
+        status_type = STATUS_EFFECT_REFRESH
+        duration = STATUS_EFFECT_PERMANENT
+        tick_interval = 1 SECONDS
+        alert_type = null
+        var/datum/weakref/cocoon_ref
+
+/datum/status_effect/changeling_chorus_stasis/on_creation(mob/living/new_owner, obj/structure/changeling_chorus_cocoon/cocoon)
+        if(istype(cocoon))
+                cocoon_ref = WEAKREF(cocoon)
+        return ..()
+
+/datum/status_effect/changeling_chorus_stasis/tick(seconds_between_ticks)
+        var/obj/structure/changeling_chorus_cocoon/cocoon = cocoon_ref?.resolve()
+        if(QDELETED(owner) || !cocoon || !(owner in cocoon.buckled_mobs))
+                qdel(src)
+                return
+        if(owner.stat == DEAD)
+                return
+        owner.adjustBruteLoss(-2.4 * seconds_between_ticks, updating_health = FALSE, forced = TRUE)
+        owner.adjustFireLoss(-2 * seconds_between_ticks, updating_health = FALSE, forced = TRUE)
+        owner.adjustOxyLoss(-3 * seconds_between_ticks, updating_health = FALSE, forced = TRUE)
+        owner.adjustToxLoss(-0.8 * seconds_between_ticks, forced = TRUE)
+        owner.adjustStaminaLoss(-6 * seconds_between_ticks, updating_stamina = FALSE)
+        owner.updatehealth()
+
+/datum/status_effect/changeling_chorus_stasis/on_remove()
+        cocoon_ref = null
+        return ..()
 
 /obj/structure/changeling_chorus_cocoon
-	name = "chorus cocoon"
-	desc = "A resonant changeling pod humming with muffled voices."
-	icon = 'icons/mob/simple/meteor_heart.dmi'
-	icon_state = "flesh_pod_open"
-	anchored = TRUE
-	density = FALSE
-	can_buckle = TRUE
-	buckle_lying = TRUE
-	max_buckled_mobs = 2
-	obj_flags = CAN_BE_HIT
-	resistance_flags = FIRE_PROOF | ACID_PROOF
-	max_integrity = 80
-	/// Changeling source maintaining the cocoon.
-	var/datum/weakref/changeling_ref
+        name = "chorus cocoon"
+        desc = "A resonant changeling pod humming with muffled voices."
+        icon = 'icons/mob/simple/meteor_heart.dmi'
+        icon_state = "flesh_pod_open"
+        anchored = TRUE
+        density = FALSE
+        can_buckle = TRUE
+        buckle_lying = TRUE
+        max_buckled_mobs = 1
+        obj_flags = CAN_BE_HIT
+        resistance_flags = FIRE_PROOF | ACID_PROOF
+        max_integrity = 80
+        /// Changeling source maintaining the cocoon.
+        var/datum/weakref/changeling_ref
+        /// Tracks mobs currently concealed by the cocoon.
+        var/list/cocooned_mobs = list()
 
 /obj/structure/changeling_chorus_cocoon/Initialize(mapload, datum/antagonist/changeling/changeling_data)
-	. = ..()
-	if(changeling_data)
-		changeling_ref = WEAKREF(changeling_data)
-	START_PROCESSING(SSobj, src)
-	update_cocoon_appearance()
-	return .
+        . = ..()
+        if(changeling_data)
+                changeling_ref = WEAKREF(changeling_data)
+        cocooned_mobs = list()
+        update_cocoon_appearance()
+        return .
 
 /obj/structure/changeling_chorus_cocoon/Destroy()
-	STOP_PROCESSING(SSobj, src)
-	for(var/mob/living/occupant in buckled_mobs.Copy())
-		unbuckle_mob(occupant, force = TRUE, can_fall = FALSE)
-	var/datum/antagonist/changeling/changeling_data = changeling_ref?.resolve()
-	changeling_data?.clear_chorus_cocoon(src)
-	changeling_ref = null
-	return ..()
-
-/obj/structure/changeling_chorus_cocoon/process(seconds_per_tick)
-	for(var/mob/living/occupant in buckled_mobs)
-		if(occupant.stat == DEAD)
-			continue
-		occupant.adjustBruteLoss(-2.4 * seconds_per_tick, updating_health = FALSE, forced = TRUE)
-		occupant.adjustFireLoss(-2 * seconds_per_tick, updating_health = FALSE, forced = TRUE)
-		occupant.adjustOxyLoss(-3 * seconds_per_tick, updating_health = FALSE, forced = TRUE)
-		occupant.adjustToxLoss(-0.8 * seconds_per_tick, forced = TRUE)
-		occupant.adjustStaminaLoss(-6 * seconds_per_tick, updating_stamina = FALSE)
-		occupant.updatehealth()
+        for(var/mob/living/occupant in buckled_mobs.Copy())
+                unbuckle_mob(occupant, force = TRUE, can_fall = FALSE)
+        for(var/mob/living/hidden in cocooned_mobs.Copy())
+                remove_cocoon_effects(hidden)
+        cocooned_mobs.Cut()
+        var/datum/antagonist/changeling/changeling_data = changeling_ref?.resolve()
+        changeling_data?.clear_chorus_cocoon(src)
+        changeling_ref = null
+        return ..()
 
 /obj/structure/changeling_chorus_cocoon/proc/add_occupant(mob/living/victim)
-	if(length(buckled_mobs) >= max_buckled_mobs)
-		return FALSE
-	if(!victim.buckle_mob(src, force = TRUE, check_loc = TRUE))
-		return FALSE
+        if(length(buckled_mobs) >= max_buckled_mobs)
+                return FALSE
+        if(!victim.buckle_mob(src, force = TRUE, check_loc = TRUE))
+                return FALSE
 	victim.visible_message(
 		span_warning("[victim] is swallowed by [src]!"),
 		span_userdanger("A thick chorus of tendrils binds you inside the cocoon!"),
 	)
-	update_cocoon_appearance()
-	return TRUE
+        return TRUE
+
+/obj/structure/changeling_chorus_cocoon/post_buckle_mob(mob/living/buckled_mob)
+        . = ..()
+        apply_cocoon_effects(buckled_mob)
+        update_cocoon_appearance()
 
 /obj/structure/changeling_chorus_cocoon/proc/update_cocoon_appearance()
-	if(length(buckled_mobs))
-		icon_state = "flesh_pod"
-	else
-		icon_state = "flesh_pod_open"
+        if(length(buckled_mobs))
+                icon_state = "flesh_pod"
+        else
+                icon_state = "flesh_pod_open"
 
 /obj/structure/changeling_chorus_cocoon/post_unbuckle_mob(mob/living/unbuckled_mob)
-	. = ..()
-	update_cocoon_appearance()
+        . = ..()
+        remove_cocoon_effects(unbuckled_mob)
+        update_cocoon_appearance()
+
+/obj/structure/changeling_chorus_cocoon/proc/apply_cocoon_effects(mob/living/victim)
+        if(!isliving(victim))
+                return
+        cocooned_mobs |= victim
+        victim.SetInvisibility(INVISIBILITY_MAXIMUM, id = REF(src))
+        ADD_TRAIT(victim, TRAIT_HANDS_BLOCKED, REF(src))
+        victim.apply_status_effect(/datum/status_effect/changeling_chorus_stasis, src)
+
+/obj/structure/changeling_chorus_cocoon/proc/remove_cocoon_effects(mob/living/victim)
+        if(!isliving(victim))
+                return
+        cocooned_mobs -= victim
+        victim.RemoveInvisibility(REF(src))
+        REMOVE_TRAIT(victim, TRAIT_HANDS_BLOCKED, REF(src))
+        if(victim.has_status_effect(/datum/status_effect/changeling_chorus_stasis))
+                victim.remove_status_effect(/datum/status_effect/changeling_chorus_stasis)
 
 /obj/structure/changeling_chorus_cocoon/proc/detonate(mob/living/user)
-	playsound(src, 'sound/effects/magic/clockwork/anima_fragment_attack.ogg', 60, TRUE)
-	visible_message(
-		span_danger("[src] ruptures in a wave of soporific gas!"),
+        playsound(src, 'sound/effects/magic/clockwork/anima_fragment_attack.ogg', 60, TRUE)
+        visible_message(
+                span_danger("[src] ruptures in a wave of soporific gas!"),
 		span_notice("We unravel the cocoon, flooding the area with muting spores."),
 	)
 	for(var/mob/living/occupant in buckled_mobs.Copy())


### PR DESCRIPTION
## Summary
- limit Chorus Stasis cocoons to a single occupant, hide the occupant, and move healing into a status effect
- update the activation logic so the changeling can cocoon either themself or a target and refresh the module description
- rework Ashen Pump and Hemolytic Bloom visuals to provide clearer fire trails and bloom detonations

## Testing
- python3 tools/validate_dme.py < tgstation.dme

------
https://chatgpt.com/codex/tasks/task_e_68d1884d1124832aadd15d3dec4e3f0d