### PR TITLE
Fix changeling DM indentation

### DIFF
--- a/code/modules/antagonists/changeling/passives/hemolytic_bloom.dm
+++ b/code/modules/antagonists/changeling/passives/hemolytic_bloom.dm
@@ -22,19 +22,19 @@
 	)
 
 /obj/effect/particle_effect/fluid/smoke/hemolytic_bloom
-       parent_type = /obj/effect/particle_effect/fluid/smoke/quick
-       lifetime = 2 SECONDS
+	parent_type = /obj/effect/particle_effect/fluid/smoke/quick
+	lifetime = 2 SECONDS
 
 /obj/effect/particle_effect/fluid/smoke/hemolytic_bloom/Initialize(mapload, datum/fluid_group/group, ...)
-       . = ..()
-       add_atom_colour("#84ff9f", FIXED_COLOUR_PRIORITY)
-       color = "#84ff9f"
+	. = ..()
+	add_atom_colour("#84ff9f", FIXED_COLOUR_PRIORITY)
+	color = "#84ff9f"
 
 /obj/effect/temp_visual/changeling_hemolytic_seed
-       name = "hemolytic bloom"
-       icon = 'icons/effects/blood.dmi'
-       icon_state = "splatter1"
-       layer = ABOVE_MOB_LAYER
+	name = "hemolytic bloom"
+	icon = 'icons/effects/blood.dmi'
+	icon_state = "splatter1"
+	layer = ABOVE_MOB_LAYER
 	plane = GAME_PLANE
 	duration = 4 SECONDS
 	light_range = 1.5
@@ -54,17 +54,17 @@
 	if(QDELETED(src))
 		return
 	playsound(src, 'sound/effects/splat.ogg', 55, TRUE)
-       visible_message(
-               span_danger("[src] ruptures into a spray of acidic spores!"),
-               span_notice("Our bloom erupts, digesting fresh biomass."),
-       )
-       var/turf/location = get_turf(src)
-       if(istype(location))
-               do_smoke(range = 1, location = location, smoke_type = /obj/effect/particle_effect/fluid/smoke/hemolytic_bloom)
-               for(var/dir in GLOB.cardinals)
-                       new /obj/effect/temp_visual/dir_setting/bloodsplatter(location, dir, "#6bff9f")
-               var/obj/effect/temp_visual/small_smoke/halfsecond/mist = new(location)
-               mist.color = "#7fffb2"
+	visible_message(
+		span_danger("[src] ruptures into a spray of acidic spores!"),
+		span_notice("Our bloom erupts, digesting fresh biomass."),
+	)
+	var/turf/location = get_turf(src)
+	if(istype(location))
+		do_smoke(range = 1, location = location, smoke_type = /obj/effect/particle_effect/fluid/smoke/hemolytic_bloom)
+		for(var/dir in GLOB.cardinals)
+			new /obj/effect/temp_visual/dir_setting/bloodsplatter(location, dir, "#6bff9f")
+		var/obj/effect/temp_visual/small_smoke/halfsecond/mist = new(location)
+		mist.color = "#7fffb2"
 	for(var/mob/living/target in range(1, src))
 		if(IS_CHANGELING(target))
 			continue

--- a/code/modules/antagonists/changeling/powers/chorus_stasis.dm
+++ b/code/modules/antagonists/changeling/powers/chorus_stasis.dm
@@ -17,10 +17,10 @@
 	return changeling_data.handle_chorus_stasis_activation(user, target)
 
 /obj/structure/changeling_chorus_cocoon
-       name = "chorus cocoon"
-       desc = "A resonant changeling pod humming with muffled voices."
-       icon = 'icons/mob/simple/meteor_heart.dmi'
-       icon_state = "flesh_pod_open"
+	name = "chorus cocoon"
+	desc = "A resonant changeling pod humming with muffled voices."
+	icon = 'icons/mob/simple/meteor_heart.dmi'
+	icon_state = "flesh_pod_open"
 	anchored = TRUE
 	density = FALSE
 	can_buckle = TRUE
@@ -31,51 +31,51 @@
 	max_integrity = 80
 	/// Changeling source maintaining the cocoon.
 	var/datum/weakref/changeling_ref
-       /// Tracks mobs currently concealed by the cocoon.
-       var/list/cocooned_mobs = list()
+	/// Tracks mobs currently concealed by the cocoon.
+	var/list/cocooned_mobs = list()
 
 /obj/structure/changeling_chorus_cocoon/Initialize(mapload, datum/antagonist/changeling/changeling_data)
-       . = ..()
-       if(changeling_data)
-               changeling_ref = WEAKREF(changeling_data)
-       cocooned_mobs = list()
-       START_PROCESSING(SSobj, src)
-       update_cocoon_appearance()
-       return .
+	. = ..()
+	if(changeling_data)
+		changeling_ref = WEAKREF(changeling_data)
+	cocooned_mobs = list()
+	START_PROCESSING(SSobj, src)
+	update_cocoon_appearance()
+	return .
 
 /obj/structure/changeling_chorus_cocoon/Destroy()
-       for(var/mob/living/occupant in buckled_mobs.Copy())
-               unbuckle_mob(occupant, force = TRUE, can_fall = FALSE)
-       for(var/mob/living/hidden in cocooned_mobs.Copy())
-               remove_cocoon_effects(hidden)
-       cocooned_mobs.Cut()
-       STOP_PROCESSING(SSobj, src)
-       var/datum/antagonist/changeling/changeling_data = changeling_ref?.resolve()
-       changeling_data?.clear_chorus_cocoon(src)
-       changeling_ref = null
-       return ..()
+	for(var/mob/living/occupant in buckled_mobs.Copy())
+		unbuckle_mob(occupant, force = TRUE, can_fall = FALSE)
+	for(var/mob/living/hidden in cocooned_mobs.Copy())
+		remove_cocoon_effects(hidden)
+	cocooned_mobs.Cut()
+	STOP_PROCESSING(SSobj, src)
+	var/datum/antagonist/changeling/changeling_data = changeling_ref?.resolve()
+	changeling_data?.clear_chorus_cocoon(src)
+	changeling_ref = null
+	return ..()
 
 /obj/structure/changeling_chorus_cocoon/process(seconds_per_tick)
-       if(!length(cocooned_mobs))
-               return
-       for(var/mob/living/victim as anything in cocooned_mobs.Copy())
-               if(QDELETED(victim) || !(victim in buckled_mobs))
-                       remove_cocoon_effects(victim)
-                       continue
-               if(victim.stat == DEAD)
-                       continue
-               heal_cocooned_mob(victim, seconds_per_tick)
+	if(!length(cocooned_mobs))
+		return
+	for(var/mob/living/victim as anything in cocooned_mobs.Copy())
+		if(QDELETED(victim) || !(victim in buckled_mobs))
+			remove_cocoon_effects(victim)
+			continue
+		if(victim.stat == DEAD)
+			continue
+		heal_cocooned_mob(victim, seconds_per_tick)
 
 /obj/structure/changeling_chorus_cocoon/proc/heal_cocooned_mob(mob/living/victim, seconds_per_tick)
-       if(!isliving(victim))
-               return
-       victim.adjustBruteLoss(-2.4 * seconds_per_tick, updating_health = FALSE, forced = TRUE)
-       victim.adjustFireLoss(-2 * seconds_per_tick, updating_health = FALSE, forced = TRUE)
-       victim.adjustOxyLoss(-3 * seconds_per_tick, updating_health = FALSE, forced = TRUE)
-       victim.adjustToxLoss(-0.8 * seconds_per_tick, forced = TRUE)
-       victim.adjustStaminaLoss(-6 * seconds_per_tick, updating_stamina = FALSE)
-       victim.updatehealth()
-       victim.update_stamina()
+	if(!isliving(victim))
+		return
+	victim.adjustBruteLoss(-2.4 * seconds_per_tick, updating_health = FALSE, forced = TRUE)
+	victim.adjustFireLoss(-2 * seconds_per_tick, updating_health = FALSE, forced = TRUE)
+	victim.adjustOxyLoss(-3 * seconds_per_tick, updating_health = FALSE, forced = TRUE)
+	victim.adjustToxLoss(-0.8 * seconds_per_tick, forced = TRUE)
+	victim.adjustStaminaLoss(-6 * seconds_per_tick, updating_stamina = FALSE)
+	victim.updatehealth()
+	victim.update_stamina()
 
 /obj/structure/changeling_chorus_cocoon/proc/add_occupant(mob/living/victim)
 	if(length(buckled_mobs) >= max_buckled_mobs)
@@ -105,39 +105,39 @@
 	update_cocoon_appearance()
 
 /obj/structure/changeling_chorus_cocoon/proc/apply_cocoon_effects(mob/living/victim)
-       if(!isliving(victim))
-               return
-       cocooned_mobs |= victim
-       victim.SetInvisibility(INVISIBILITY_MAXIMUM, id = REF(src))
-       ADD_TRAIT(victim, TRAIT_HANDS_BLOCKED, REF(src))
+	if(!isliving(victim))
+		return
+	cocooned_mobs |= victim
+	victim.SetInvisibility(INVISIBILITY_MAXIMUM, id = REF(src))
+	ADD_TRAIT(victim, TRAIT_HANDS_BLOCKED, REF(src))
 
 /obj/structure/changeling_chorus_cocoon/proc/remove_cocoon_effects(mob/living/victim)
-       if(!isliving(victim))
-               return
-       cocooned_mobs -= victim
-       victim.RemoveInvisibility(REF(src))
-       REMOVE_TRAIT(victim, TRAIT_HANDS_BLOCKED, REF(src))
+	if(!isliving(victim))
+		return
+	cocooned_mobs -= victim
+	victim.RemoveInvisibility(REF(src))
+	REMOVE_TRAIT(victim, TRAIT_HANDS_BLOCKED, REF(src))
 
 /obj/structure/changeling_chorus_cocoon/attack_hand(mob/user, list/modifiers)
-       . = ..()
-       if(!isliving(user))
-               return TRUE
-       if(HAS_TRAIT(user, TRAIT_HANDS_BLOCKED))
-               return TRUE
-       user.visible_message(
-               span_warning("[user] claws at [src], tearing at its tendrils!"),
-               span_warning("You start ripping apart the cocoon..."),
-       )
-       if(!do_after(user, 2.5 SECONDS, target = src))
-               return TRUE
-       if(QDELETED(src))
-               return TRUE
-       visible_message(
-               span_danger("[src] splits apart under the assault!"),
-               span_notice("We rip open the cocoon."),
-       )
-       qdel(src)
-       return TRUE
+	. = ..()
+	if(!isliving(user))
+		return TRUE
+	if(HAS_TRAIT(user, TRAIT_HANDS_BLOCKED))
+		return TRUE
+	user.visible_message(
+		span_warning("[user] claws at [src], tearing at its tendrils!"),
+		span_warning("You start ripping apart the cocoon..."),
+	)
+	if(!do_after(user, 2.5 SECONDS, target = src))
+		return TRUE
+	if(QDELETED(src))
+		return TRUE
+	visible_message(
+		span_danger("[src] splits apart under the assault!"),
+		span_notice("We rip open the cocoon."),
+	)
+	qdel(src)
+	return TRUE
 
 /obj/structure/changeling_chorus_cocoon/proc/detonate(mob/living/user)
 	playsound(src, 'sound/effects/magic/clockwork/anima_fragment_attack.ogg', 60, TRUE)

--- a/code/modules/antagonists/changeling/powers/spore_node.dm
+++ b/code/modules/antagonists/changeling/powers/spore_node.dm
@@ -65,11 +65,11 @@
 	var/list/tracked_refs = list()
 
 /obj/structure/changeling_spore_node/Initialize(mapload, datum/antagonist/changeling/changeling_data)
-       . = ..()
-       if(changeling_data)
-               changeling_ref = WEAKREF(changeling_data)
-       START_PROCESSING(SSobj, src)
-       return .
+	. = ..()
+	if(changeling_data)
+		changeling_ref = WEAKREF(changeling_data)
+	START_PROCESSING(SSobj, src)
+	return .
 
 /obj/structure/changeling_spore_node/Destroy()
 	STOP_PROCESSING(SSobj, src)
@@ -106,15 +106,15 @@
 	to_chat(owner, span_changeling("Our spore node senses movement near [victim]."))
 
 /obj/structure/changeling_spore_node/proc/detonate(mob/living/user)
-       playsound(src, 'sound/effects/magic/disable_tech.ogg', 60, TRUE)
-       visible_message(
-               span_danger("[src] ruptures into a haze of grasping spores!"),
-               span_notice("Our spores rupture into a slowing miasma."),
-       )
-       do_smoke(range = 1, location = loc)
-       for(var/mob/living/target in range(3, src))
-               if(target.stat == DEAD || IS_CHANGELING(target))
-                       continue
+	playsound(src, 'sound/effects/magic/disable_tech.ogg', 60, TRUE)
+	visible_message(
+		span_danger("[src] ruptures into a haze of grasping spores!"),
+		span_notice("Our spores rupture into a slowing miasma."),
+	)
+	do_smoke(range = 1, location = loc)
+	for(var/mob/living/target in range(3, src))
+		if(target.stat == DEAD || IS_CHANGELING(target))
+			continue
 		target.adjustStaminaLoss(40)
 		target.Knockdown(2 SECONDS)
 		target.apply_status_effect(/datum/status_effect/dazed, 6 SECONDS)


### PR DESCRIPTION
## Summary
- replace leading spaces with tabs in the changeling hemolytic bloom passive definitions
- fix inconsistent indentation in changeling chorus stasis cocoon logic
- correct spore node indentation so DreamMaker parses the arguments properly

## Testing
- not run (BYOND compiler unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d1b64544f4832a97ce37a0e16834de