### PR TITLE
Fix chorus stasis cocoons

### DIFF
--- a/code/_globalvars/lists/objects.dm
+++ b/code/_globalvars/lists/objects.dm
@@ -4,6 +4,9 @@ GLOBAL_LIST_EMPTY(cable_list)
 /// List of all portals
 GLOBAL_LIST_EMPTY(portals)
 
+/// Active changeling chorus cocoons tracked for cleanup and limiting
+GLOBAL_LIST_EMPTY(changeling_chorus_cocoons)
+
 /// List of all curtains for button tracking
 GLOBAL_LIST_EMPTY(curtains)
 


### PR DESCRIPTION
## Summary
- track chorus stasis cocoons globally so changelings can only maintain one active pod and stale pods are cleaned up
- refresh cocoon processing to always heal buckled occupants and clear invalid entries

## Testing
- ⚠️ `python3 tools/validate_dme.py tgstation.dme` (hangs waiting for stdin, aborted)


------
https://chatgpt.com/codex/tasks/task_e_68d1bb76d0d4832aa4d4b6cd0c0bbcfa