### PR TITLE
Fix changeling DM indentation to resolve compile errors

### DIFF
--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -82,8 +82,8 @@
 	var/matrix_predatory_howl_active = FALSE
 	/// Whether the symbiotic overgrowth matrix module is active.
 	var/matrix_symbiotic_overgrowth_active = FALSE
-        /// Whether the predator sinew matrix module is active.
-        var/matrix_predator_sinew_active = FALSE
+	/// Whether the predator sinew matrix module is active.
+	var/matrix_predator_sinew_active = FALSE
 	/// Whether the void carapace matrix module is active.
 	var/matrix_void_carapace_active = FALSE
 	/// Whether the adrenal spike matrix module is active.
@@ -315,8 +315,8 @@
 	handle_clown_mutation(living_mob, removing = FALSE)
 	UnregisterSignal(living_mob, list(COMSIG_MOB_LOGIN, COMSIG_LIVING_LIFE, COMSIG_LIVING_POST_FULLY_HEAL, COMSIG_MOB_GET_STATUS_TAB_ITEMS, COMSIG_MOB_MIDDLECLICKON, COMSIG_MOB_ALTCLICKON))
 	REMOVE_TRAIT(living_mob, TRAIT_FAKE_SOULLESS, CHANGELING_TRAIT)
-        unbind_predator_sinew_signals()
-        unbind_anaerobic_reservoir_signals()
+	unbind_predator_sinew_signals()
+	unbind_anaerobic_reservoir_signals()
 
 	if(living_mob.hud_used)
 		var/datum/hud/hud_used = living_mob.hud_used
@@ -435,7 +435,7 @@
 	current_matrix_module_ids = active_ids
 	update_matrix_predatory_howl("matrix_predatory_howl" in active_ids)
 	update_matrix_symbiotic_overgrowth("matrix_symbiotic_overgrowth" in active_ids)
-        update_matrix_predator_sinew_effect("matrix_predator_sinew" in active_ids)
+	update_matrix_predator_sinew_effect("matrix_predator_sinew" in active_ids)
 	update_matrix_void_carapace_effect("matrix_void_carapace" in active_ids)
 	update_matrix_adrenal_spike_effect("matrix_adrenal_spike" in active_ids)
 	update_matrix_aether_drake_effect("matrix_aether_drake_mantle" in active_ids)
@@ -480,8 +480,8 @@
 	matrix_symbiotic_overgrowth_active = !!is_active
 
 /datum/antagonist/changeling/proc/update_matrix_predator_sinew_effect(is_active)
-        matrix_predator_sinew_active = !!is_active
-        if(!matrix_predator_sinew_active)
+	matrix_predator_sinew_active = !!is_active
+	if(!matrix_predator_sinew_active)
 		unbind_predator_sinew_signals()
 		return
 	bind_predator_sinew_signals(owner?.current)
@@ -753,14 +753,14 @@
 	matrix_abyssal_slip_bound_mob = null
 
 /datum/antagonist/changeling/proc/on_abyssal_slip_moved(atom/movable/source, atom/old_loc, move_dir, forced, list/atom/old_locs)
-        SIGNAL_HANDLER
-        if(!matrix_abyssal_slip_active || source != matrix_abyssal_slip_bound_mob)
-                return
-        var/mob/living/living_owner = matrix_abyssal_slip_bound_mob
-        if(!living_owner)
-                return
-        var/datum/status_effect/darkness_adapted/adaptation = living_owner.has_status_effect(/datum/status_effect/darkness_adapted)
-        adaptation?.update_invis()
+	SIGNAL_HANDLER
+	if(!matrix_abyssal_slip_active || source != matrix_abyssal_slip_bound_mob)
+		return
+	var/mob/living/living_owner = matrix_abyssal_slip_bound_mob
+	if(!living_owner)
+		return
+	var/datum/status_effect/darkness_adapted/adaptation = living_owner.has_status_effect(/datum/status_effect/darkness_adapted)
+	adaptation?.update_invis()
 
 /datum/antagonist/changeling/proc/update_matrix_crystalline_buffer_effect(is_active)
 	matrix_crystalline_buffer_active = !!is_active
@@ -1130,14 +1130,14 @@
 	genetic_matrix_effect_cache = changeling_get_default_matrix_effects()
 
 /datum/antagonist/changeling/proc/update_matrix_passive_effects(list/active_ids)
-        var/static/list/multiplicative_effect_keys = list(
-                "stamina_use_mult",
-                "stamina_regen_time_mult",
-                "fleshmend_heal_mult",
-                "biodegrade_timer_mult",
-                "resonant_shriek_confusion_mult",
-                "dissonant_shriek_structure_mult",
-        )
+	var/static/list/multiplicative_effect_keys = list(
+		"stamina_use_mult",
+		"stamina_regen_time_mult",
+		"fleshmend_heal_mult",
+		"biodegrade_timer_mult",
+		"resonant_shriek_confusion_mult",
+		"dissonant_shriek_structure_mult",
+	)
 	var/list/effect_totals = changeling_get_default_matrix_effects()
 	if(islist(active_ids))
 		for(var/module_id in active_ids)

--- a/code/modules/antagonists/changeling/passives/abyssal_slip.dm
+++ b/code/modules/antagonists/changeling/passives/abyssal_slip.dm
@@ -3,22 +3,22 @@
 /datum/changeling_genetic_matrix_recipe/abyssal_slip
 	id = "matrix_abyssal_slip"
 	name = "Abyssal Slip"
-        description = "Fuse Teshari sprint tendons with shadekin film to melt into station shadows and walls."
-        module = list(
-                        "id" = "matrix_abyssal_slip",
-                        "name" = "Abyssal Slip",
-                        "desc" = "Grants silent footsteps, smoother transitions with Darkness Adaptation, and a slight speed edge while skulking.",
-                        "category" = GENETIC_MATRIX_CATEGORY_PASSIVE,
-                        "slotType" = BIO_INCUBATOR_SLOT_FLEX,
-                        "tags" = list("stealth", "mobility"),
+	description = "Fuse Teshari sprint tendons with shadekin film to melt into station shadows and walls."
+	module = list(
+			"id" = "matrix_abyssal_slip",
+			"name" = "Abyssal Slip",
+			"desc" = "Grants silent footsteps, smoother transitions with Darkness Adaptation, and a slight speed edge while skulking.",
+			"category" = GENETIC_MATRIX_CATEGORY_PASSIVE,
+			"slotType" = BIO_INCUBATOR_SLOT_FLEX,
+			"tags" = list("stealth", "mobility"),
 			"effects" = list(
-                        "move_speed_slowdown" = -0.3,
+			"move_speed_slowdown" = -0.3,
 			),
 	)
 	required_cells = list(
 			CHANGELING_CELL_ID_TESHARI,
 			CHANGELING_CELL_ID_SHADEKIN,
 	)
-        required_abilities = list(
-                        /datum/action/changeling/darkness_adaptation,
-        )
+	required_abilities = list(
+			/datum/action/changeling/darkness_adaptation,
+	)

--- a/code/modules/antagonists/changeling/powers/chameleon_skin.dm
+++ b/code/modules/antagonists/changeling/powers/chameleon_skin.dm
@@ -12,14 +12,14 @@
 	if(!istype(cling)) // req_human could be done in can_sting stuff.
 		return
 	..()
-        if(cling.dna.get_mutation(/datum/mutation/chameleon/changeling))
-                cling.dna.remove_mutation(/datum/mutation/chameleon/changeling, MUTATION_SOURCE_CHANGELING)
-        else
-                cling.dna.add_mutation(/datum/mutation/chameleon/changeling, MUTATION_SOURCE_CHANGELING)
-        return TRUE
+	if(cling.dna.get_mutation(/datum/mutation/chameleon/changeling))
+		cling.dna.remove_mutation(/datum/mutation/chameleon/changeling, MUTATION_SOURCE_CHANGELING)
+	else
+		cling.dna.add_mutation(/datum/mutation/chameleon/changeling, MUTATION_SOURCE_CHANGELING)
+	return TRUE
 
 /datum/action/changeling/chameleon_skin/Remove(mob/user)
-        if(user.has_dna())
-                var/mob/living/carbon/cling = user
-                cling.dna.remove_mutation(/datum/mutation/chameleon/changeling, MUTATION_SOURCE_CHANGELING)
-        ..()
+	if(user.has_dna())
+		var/mob/living/carbon/cling = user
+		cling.dna.remove_mutation(/datum/mutation/chameleon/changeling, MUTATION_SOURCE_CHANGELING)
+	..()

--- a/code/modules/antagonists/changeling/powers/digitalcamo.dm
+++ b/code/modules/antagonists/changeling/powers/digitalcamo.dm
@@ -17,8 +17,8 @@
 		to_chat(user, span_notice("We distort our form to hide from the AI."))
 		user.AddElement(/datum/element/digitalcamo)
 		active = TRUE
-        return TRUE
+	return TRUE
 
 /datum/action/changeling/digitalcamo/Remove(mob/user)
-        user.RemoveElement(/datum/element/digitalcamo)
-        ..()
+	user.RemoveElement(/datum/element/digitalcamo)
+	..()


### PR DESCRIPTION
## Summary
- Normalize indentation in changeling antagonist definitions that mixed tabs and spaces
- Align abyssal slip, chameleon skin, and digital camouflage files with tabbed indentation to satisfy DreamMaker

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d4026bdab08330813bc8b39077281d