### PR TITLE
Add module types to changeling genetic matrix

### DIFF
--- a/code/modules/antagonists/changeling/genetic_matrix_content.dm
+++ b/code/modules/antagonists/changeling/genetic_matrix_content.dm
@@ -2,6 +2,7 @@
 #define GENETIC_MATRIX_CATEGORY_PASSIVE "passive"
 #define GENETIC_MATRIX_CATEGORY_UPGRADE "upgrade"
 
+GLOBAL_LIST_EMPTY(changeling_genetic_module_types)
 GLOBAL_LIST_INIT(changeling_genetic_matrix_recipes, setup_changeling_genetic_matrix_recipes())
 
 /// Movespeed modifier used for genetic matrix passive bonuses.
@@ -19,6 +20,8 @@ GLOBAL_LIST_INIT(changeling_genetic_matrix_recipes, setup_changeling_genetic_mat
         var/description = ""
         /// Metadata describing the crafted module.
         var/list/module = list()
+        /// The module type spawned when crafting this recipe.
+        var/module_type
         /// Cells required to craft the recipe.
         var/list/required_cells = list()
         /// Abilities required to unlock the recipe.
@@ -36,6 +39,8 @@ GLOBAL_LIST_INIT(changeling_genetic_matrix_recipes, setup_changeling_genetic_mat
                 block["name"] = name
         if(!block["desc"])
                 block["desc"] = description
+        if(module_type && !block["moduleType"])
+                block["moduleType"] = module_type
         if(islist(block["effects"]))
                 block["effects"] = block["effects"].Copy()
         return block
@@ -60,6 +65,7 @@ GLOBAL_LIST_INIT(changeling_genetic_matrix_recipes, setup_changeling_genetic_mat
 /// Assemble the genetic matrix recipe catalog from all defined recipes.
 /proc/setup_changeling_genetic_matrix_recipes()
         var/list/output = list()
+        GLOB.changeling_genetic_module_types = list()
         for(var/recipe_type as anything in subtypesof(/datum/changeling_genetic_matrix_recipe))
                 if(recipe_type == /datum/changeling_genetic_matrix_recipe)
                         continue
@@ -74,6 +80,11 @@ GLOBAL_LIST_INIT(changeling_genetic_matrix_recipes, setup_changeling_genetic_mat
                         qdel(recipe)
                         continue
                 output[recipe_id] = data
+                var/list/module_data = data["module"]
+                if(islist(module_data))
+                        var/module_type = module_data["moduleType"]
+                        if(ispath(module_type, /datum/changeling_genetic_module))
+                                GLOB.changeling_genetic_module_types[recipe_id] = module_type
                 qdel(recipe)
         return output
 

--- a/code/modules/antagonists/changeling/passives/abyssal_slip.dm
+++ b/code/modules/antagonists/changeling/passives/abyssal_slip.dm
@@ -1,4 +1,9 @@
 /// Passive: Abyssal Slip — braids teshari sprint tendons, fox pads, and mothroach clingers for silent, shadow-hugging movement.
+/datum/changeling_genetic_module/passive/abyssal_slip
+	passive_effects = list(
+		"move_speed_slowdown" = -0.05,
+	)
+
 /datum/changeling_genetic_matrix_recipe/abyssal_slip
 	id = "matrix_abyssal_slip"
 	name = "Abyssal Slip"
@@ -9,6 +14,7 @@
 		"desc" = "Grants silent footsteps, smoother transitions with Darkness Adaptation, and a slight speed edge while skulking.",
 		"category" = GENETIC_MATRIX_CATEGORY_PASSIVE,
 		"slotType" = BIO_INCUBATOR_SLOT_FLEX,
+		"moduleType" = /datum/changeling_genetic_module/passive/abyssal_slip,
 		"tags" = list("stealth", "mobility"),
 		"effects" = list(
 			"move_speed_slowdown" = -0.05,

--- a/code/modules/antagonists/changeling/passives/adrenal_spike.dm
+++ b/code/modules/antagonists/changeling/passives/adrenal_spike.dm
@@ -1,4 +1,7 @@
 /// Upgrade: Adrenal Spike — distills human adrenaline, goat stamina reserves, and rabbit twitch muscles into a reactive countershock for Gene Stim.
+/datum/changeling_genetic_module/upgrade/adrenal_spike
+	passive_effects = list()
+
 /datum/changeling_genetic_matrix_recipe/adrenal_spike
 	id = "matrix_adrenal_spike"
 	name = "Adrenal Spike"
@@ -9,6 +12,7 @@
 		"desc" = "Upgrades Gene Stim with bonus stamina recovery and a reactive countershock when stunned.",
 		"category" = GENETIC_MATRIX_CATEGORY_UPGRADE,
 		"slotType" = BIO_INCUBATOR_SLOT_FLEX,
+		"moduleType" = /datum/changeling_genetic_module/upgrade/adrenal_spike,
 		"tags" = list("stamina", "burst"),
 		"exclusiveTags" = list("stamina"),
 		"button_icon_state" = "adrenaline",

--- a/code/modules/antagonists/changeling/passives/aether_drake_mantle.dm
+++ b/code/modules/antagonists/changeling/passives/aether_drake_mantle.dm
@@ -1,5 +1,11 @@
 
 /// Passive: Aether Drake Mantle — weaves vulpkanin cold coats, space dragon plasma scales, and ash drake furnace plates into resilient void plating.
+/datum/changeling_genetic_module/passive/aether_drake_mantle
+	passive_effects = list(
+		"incoming_brute_damage_mult" = 0.7,
+		"incoming_burn_damage_mult" = 0.7,
+	)
+
 /datum/changeling_genetic_matrix_recipe/aether_drake_mantle
 	id = "matrix_aether_drake_mantle"
 	name = "Aether Drake Mantle"
@@ -10,6 +16,7 @@
 			"desc" = "Remixes Void Adaption with manual EVA bursts, space mobility traits, and reinforced resistances.",
 			"category" = GENETIC_MATRIX_CATEGORY_PASSIVE,
 		"slotType" = BIO_INCUBATOR_SLOT_FLEX,
+		"moduleType" = /datum/changeling_genetic_module/passive/aether_drake_mantle,
 		"tags" = list("mobility", "environment"),
 		"exclusiveTags" = list("adaptation"),
 		"effects" = list(

--- a/code/modules/antagonists/changeling/passives/anaerobic_reservoir.dm
+++ b/code/modules/antagonists/changeling/passives/anaerobic_reservoir.dm
@@ -1,4 +1,10 @@
 /// Passive: Anaerobic Reservoir — layers human training lungs, goat stamina hearts, and pig blood caches to thicken our stamina pool.
+/datum/changeling_genetic_module/passive/anaerobic_reservoir
+	passive_effects = list(
+		"max_stamina_add" = 40,
+		"stamina_use_mult" = 0.9,
+	)
+
 /datum/changeling_genetic_matrix_recipe/anaerobic_reservoir
 	id = "matrix_anaerobic_reservoir"
 	name = "Anaerobic Reservoir"
@@ -9,6 +15,7 @@
 		"desc" = "Adds a reserve of stamina and trims everyday expenditure, then erupts near collapse to refill us and cushion the next impact.",
 		"category" = GENETIC_MATRIX_CATEGORY_PASSIVE,
 		"slotType" = BIO_INCUBATOR_SLOT_FLEX,
+		"moduleType" = /datum/changeling_genetic_module/passive/anaerobic_reservoir,
 		"tags" = list("stamina", "resilience"),
 		"exclusiveTags" = list("stamina_reservoir"),
 		"button_icon_state" = null,

--- a/code/modules/antagonists/changeling/passives/ashen_pump.dm
+++ b/code/modules/antagonists/changeling/passives/ashen_pump.dm
@@ -1,5 +1,8 @@
 
 /// Upgrade: Ashen Pump — superheats Gene Stim with tajaran heat glands, ash drake embers, and Bubblegum furnace bile.
+/datum/changeling_genetic_module/upgrade/ashen_pump
+	passive_effects = list()
+
 /datum/changeling_genetic_matrix_recipe/ashen_pump
 	id = "matrix_ashen_pump"
 	name = "Ashen Pump"
@@ -10,6 +13,7 @@
 			"desc" = "Gene Stim leaves a plasma flare trail, reduces burn damage, and extends its rush at extra chem cost.",
 			"category" = GENETIC_MATRIX_CATEGORY_UPGRADE,
 			"slotType" = BIO_INCUBATOR_SLOT_FLEX,
+		"moduleType" = /datum/changeling_genetic_module/upgrade/ashen_pump,
 			"tags" = list("gene_stim", "burn"),
 			"exclusiveTags" = list("gene_stim"),
 			"button_icon_state" = "adrenaline",

--- a/code/modules/antagonists/changeling/passives/barbed_larynx.dm
+++ b/code/modules/antagonists/changeling/passives/barbed_larynx.dm
@@ -1,4 +1,10 @@
 /// Passive: Barbed Larynx — reshapes our voicebox with felinid vibrato cords, parrot mimicry larynxes, and bee resonance combs to amplify sonic assaults.
+/datum/changeling_genetic_module/passive/barbed_larynx
+	passive_effects = list(
+		"resonant_shriek_range_add" = 2,
+		"resonant_shriek_confusion_mult" = 1.1,
+	)
+
 /datum/changeling_genetic_matrix_recipe/barbed_larynx
 	id = "matrix_barbed_larynx"
 	name = "Barbed Larynx"
@@ -9,6 +15,7 @@
 		"desc" = "Bolsters our sonic shrieks with broader reach and lingering vertigo.",
 		"category" = GENETIC_MATRIX_CATEGORY_PASSIVE,
 		"slotType" = BIO_INCUBATOR_SLOT_FLEX,
+		"moduleType" = /datum/changeling_genetic_module/passive/barbed_larynx,
 		"tags" = list("sonic", "crowd_control"),
 		"exclusiveTags" = list("shriek_range"),
 		"button_icon_state" = "resonant_shriek",

--- a/code/modules/antagonists/changeling/passives/bioelectric_coils.dm
+++ b/code/modules/antagonists/changeling/passives/bioelectric_coils.dm
@@ -1,4 +1,11 @@
 /// Passive: Bioelectric Coils — weaves slimeperson conduits, glockroach capacitors, and space carp charge sinks to supercharge every stride while shrugging off fatigue.
+/datum/changeling_genetic_module/passive/bioelectric_coils
+	passive_effects = list(
+		"move_speed_slowdown" = -0.04,
+		"stamina_use_mult" = 0.8,
+		"stamina_regen_time_mult" = 0.7,
+	)
+
 /datum/changeling_genetic_matrix_recipe/bioelectric_coils
 	id = "matrix_bioelectric_coils"
 	name = "Bioelectric Coils"
@@ -10,6 +17,7 @@
 		"helptext" = "Too potent for flex slots; occupies a key conduit.",
 		"category" = GENETIC_MATRIX_CATEGORY_PASSIVE,
 		"slotType" = BIO_INCUBATOR_SLOT_KEY,
+		"moduleType" = /datum/changeling_genetic_module/passive/bioelectric_coils,
 		"tags" = list("mobility", "stamina"),
 		"exclusiveTags" = list("key_speed"),
 		"button_icon_state" = null,

--- a/code/modules/antagonists/changeling/passives/cacophony_gland.dm
+++ b/code/modules/antagonists/changeling/passives/cacophony_gland.dm
@@ -1,4 +1,10 @@
 /// Upgrade: Cacophony Gland — reworks our lungs with vulpkanin hunting howls, corgi pack bellows, and pug pressure veins to weaponize the dissonant shriek.
+/datum/changeling_genetic_module/upgrade/cacophony_gland
+	passive_effects = list(
+		"dissonant_shriek_emp_range_add" = 2,
+		"dissonant_shriek_structure_mult" = 1.3,
+	)
+
 /datum/changeling_genetic_matrix_recipe/cacophony_gland
 	id = "matrix_cacophony_gland"
 	name = "Cacophony Gland"
@@ -10,6 +16,7 @@
 		"helptext" = "Occupies a key slot due to the overwhelming pressure it exerts.",
 		"category" = GENETIC_MATRIX_CATEGORY_UPGRADE,
 		"slotType" = BIO_INCUBATOR_SLOT_KEY,
+		"moduleType" = /datum/changeling_genetic_module/upgrade/cacophony_gland,
 		"tags" = list("sonic", "siege"),
 		"exclusiveTags" = list("shriek_upgrade"),
 		"button_icon_state" = "dissonant_shriek",

--- a/code/modules/antagonists/changeling/passives/chitin_courier.dm
+++ b/code/modules/antagonists/changeling/passives/chitin_courier.dm
@@ -1,5 +1,8 @@
 
 /// Passive: Chitin Courier — folds slimeperson cytogel, mothroach clingers, and cargo crab plating into a hidden subdermal cargo pocket.
+/datum/changeling_genetic_module/passive/chitin_courier
+	passive_effects = list()
+
 /datum/changeling_genetic_matrix_recipe/chitin_courier
 	id = "matrix_chitin_courier"
 	name = "Chitin Courier"
@@ -10,6 +13,7 @@
 		"desc" = "Adds a quick-action subdermal stash for a medium item, perfect for contraband swaps.",
 			"category" = GENETIC_MATRIX_CATEGORY_PASSIVE,
 			"slotType" = BIO_INCUBATOR_SLOT_FLEX,
+		"moduleType" = /datum/changeling_genetic_module/passive/chitin_courier,
 			"tags" = list("utility", "stealth"),
 	)
 	required_cells = list(

--- a/code/modules/antagonists/changeling/passives/corrosive_bile.dm
+++ b/code/modules/antagonists/changeling/passives/corrosive_bile.dm
@@ -1,4 +1,10 @@
 /// Upgrade: Corrosive Bile — distills slimeperson acid bladders, morph solvent sacs, and giant spider venoms to melt restraints in moments with less expenditure.
+/datum/changeling_genetic_module/upgrade/corrosive_bile
+	passive_effects = list(
+		"biodegrade_timer_mult" = 0.4,
+		"biodegrade_chem_discount" = 16,
+	)
+
 /datum/changeling_genetic_matrix_recipe/corrosive_bile
 	id = "matrix_corrosive_bile"
 	name = "Corrosive Bile"
@@ -9,6 +15,7 @@
 		"desc" = "Speeds up Biodegrade reactions while shaving their chemical costs.",
 		"category" = GENETIC_MATRIX_CATEGORY_UPGRADE,
 		"slotType" = BIO_INCUBATOR_SLOT_FLEX,
+		"moduleType" = /datum/changeling_genetic_module/upgrade/corrosive_bile,
 		"tags" = list("acid", "escape"),
 		"exclusiveTags" = list("biodegrade_upgrade"),
 		"button_icon_state" = "biodegrade",

--- a/code/modules/antagonists/changeling/passives/crystalline_buffer.dm
+++ b/code/modules/antagonists/changeling/passives/crystalline_buffer.dm
@@ -1,4 +1,7 @@
 /// Passive: Crystalline Buffer — suspends human riot plating, colossus prism shards, and watcher frost cores as ablative, chem-feeding barrier charges.
+/datum/changeling_genetic_module/passive/crystalline_buffer
+	passive_effects = list()
+
 /datum/changeling_genetic_matrix_recipe/crystalline_buffer
 	id = "matrix_crystalline_buffer"
 	name = "Crystalline Buffer"
@@ -9,6 +12,7 @@
 		"desc" = "Stores four refueling prism charges that negate incoming stuns before erupting in a blinding flash.",
 		"category" = GENETIC_MATRIX_CATEGORY_PASSIVE,
 		"slotType" = BIO_INCUBATOR_SLOT_FLEX,
+		"moduleType" = /datum/changeling_genetic_module/passive/crystalline_buffer,
 		"tags" = list("defense", "chemicals"),
 		"exclusiveTags" = list("shield"),
 	)

--- a/code/modules/antagonists/changeling/passives/echo_cascade.dm
+++ b/code/modules/antagonists/changeling/passives/echo_cascade.dm
@@ -1,5 +1,8 @@
 
 /// Upgrade: Echo Cascade — layers teshari overtones, parrot mimic chords, and butterfly wing chimes for delayed sonic aftershocks and EMP rebounds.
+/datum/changeling_genetic_module/upgrade/echo_cascade
+	passive_effects = list()
+
 /datum/changeling_genetic_matrix_recipe/echo_cascade
 	id = "matrix_echo_cascade"
 	name = "Echo Cascade"
@@ -10,6 +13,7 @@
 			"desc" = "Resonant and dissonant shrieks spawn delayed pulses that disorient prey and spark mini-EMPs.",
 			"category" = GENETIC_MATRIX_CATEGORY_UPGRADE,
 			"slotType" = BIO_INCUBATOR_SLOT_FLEX,
+		"moduleType" = /datum/changeling_genetic_module/upgrade/echo_cascade,
 			"tags" = list("sonic", "crowd_control"),
 			"button_icon_state" = "resonant_shriek",
 	)

--- a/code/modules/antagonists/changeling/passives/graviton_ripsaw.dm
+++ b/code/modules/antagonists/changeling/passives/graviton_ripsaw.dm
@@ -1,5 +1,8 @@
 
 /// Upgrade: Graviton Ripsaw — braids tajaran pounce tendons, voidwalker gravity shears, and space carp momentum fins into our armblade for gravitational sweeps.
+/datum/changeling_genetic_module/upgrade/graviton_ripsaw
+	passive_effects = list()
+
 /datum/changeling_genetic_matrix_recipe/graviton_ripsaw
 	id = "matrix_graviton_ripsaw"
 	name = "Graviton Ripsaw"
@@ -10,6 +13,7 @@
 		"desc" = "Arm Blade attacks yank victims inward while right-click launches a flesh tether to reel ourselves forward.",
 		"category" = GENETIC_MATRIX_CATEGORY_UPGRADE,
 		"slotType" = BIO_INCUBATOR_SLOT_FLEX,
+		"moduleType" = /datum/changeling_genetic_module/upgrade/graviton_ripsaw,
 		"tags" = list("arm_blade", "control", "mobility"),
 		"button_icon_state" = "armblade",
 )

--- a/code/modules/antagonists/changeling/passives/hemolytic_bloom.dm
+++ b/code/modules/antagonists/changeling/passives/hemolytic_bloom.dm
@@ -1,5 +1,8 @@
 
 /// Upgrade: Hemolytic Bloom — seeds the arm blade with hemophage blooms, glockroach charge sacs, and slaughter demon gore anchors that harvest blood and detonate caustic spores.
+/datum/changeling_genetic_module/upgrade/hemolytic_bloom
+	passive_effects = list()
+
 /datum/changeling_genetic_matrix_recipe/hemolytic_bloom
 	id = "matrix_hemolytic_bloom"
 	name = "Hemolytic Bloom"
@@ -10,6 +13,7 @@
 			"desc" = "Arm Blade strikes intensify bleeding, refund chems, and slain victims erupt into caustic spores.",
 			"category" = GENETIC_MATRIX_CATEGORY_UPGRADE,
 			"slotType" = BIO_INCUBATOR_SLOT_FLEX,
+		"moduleType" = /datum/changeling_genetic_module/upgrade/hemolytic_bloom,
 			"tags" = list("arm_blade", "sustain"),
 			"button_icon_state" = "armblade",
 	)

--- a/code/modules/antagonists/changeling/passives/hypermetabolic_drive.dm
+++ b/code/modules/antagonists/changeling/passives/hypermetabolic_drive.dm
@@ -1,4 +1,10 @@
 /// Passive: Hypermetabolic Drive — splices teshari twitch muscle, rabbit sprint tendons, and space carp charge fins for relentless pace.
+/datum/changeling_genetic_module/passive/hypermetabolic_drive
+	passive_effects = list(
+		"move_speed_slowdown" = -0.03,
+		"stamina_regen_time_mult" = 0.8,
+	)
+
 /datum/changeling_genetic_matrix_recipe/hypermetabolic_drive
 	id = "matrix_hypermetabolic_drive"
 	name = "Hypermetabolic Drive"
@@ -9,6 +15,7 @@
 		"desc" = "Increases our default stride and hastens stamina rebound between bursts of speed.",
 		"category" = GENETIC_MATRIX_CATEGORY_PASSIVE,
 		"slotType" = BIO_INCUBATOR_SLOT_FLEX,
+		"moduleType" = /datum/changeling_genetic_module/passive/hypermetabolic_drive,
 		"tags" = list("mobility", "stamina"),
 		"exclusiveTags" = list("speed_boost"),
 		"button_icon_state" = null,

--- a/code/modules/antagonists/changeling/passives/marrow_battery.dm
+++ b/code/modules/antagonists/changeling/passives/marrow_battery.dm
@@ -1,4 +1,10 @@
 /// Passive: Marrow Battery — cultivates hemophage marrow, cow endurance blood, and sheep insulating plasma that refuels our chemical reserves on its own.
+/datum/changeling_genetic_module/passive/marrow_battery
+	passive_effects = list(
+		"chem_recharge_rate_add" = 1.2,
+		"stamina_regen_time_mult" = 0.9,
+	)
+
 /datum/changeling_genetic_matrix_recipe/marrow_battery
 	id = "matrix_marrow_battery"
 	name = "Marrow Battery"
@@ -9,6 +15,7 @@
 		"desc" = "Accelerates baseline chemical regeneration while gently easing stamina recovery downtime.",
 		"category" = GENETIC_MATRIX_CATEGORY_PASSIVE,
 		"slotType" = BIO_INCUBATOR_SLOT_FLEX,
+		"moduleType" = /datum/changeling_genetic_module/passive/marrow_battery,
 		"tags" = list("chemicals", "sustain"),
 		"exclusiveTags" = list("chem_pool"),
 		"button_icon_state" = null,

--- a/code/modules/antagonists/changeling/passives/neuro_sap.dm
+++ b/code/modules/antagonists/changeling/passives/neuro_sap.dm
@@ -1,5 +1,8 @@
 
 /// Upgrade: Neuro Sap — steeps Panacea with slimeperson buffer gel, bee toxin filters, and Legion null-masks that harden us against toxins and radiation.
+/datum/changeling_genetic_module/upgrade/neuro_sap
+	passive_effects = list()
+
 /datum/changeling_genetic_matrix_recipe/neuro_sap
 	id = "matrix_neuro_sap"
 	name = "Neuro Sap"
@@ -10,6 +13,7 @@
 			"desc" = "Panacea leaves a regenerative film that shrugs toxins, slows radiation, and boosts chem recharge.",
 			"category" = GENETIC_MATRIX_CATEGORY_UPGRADE,
 			"slotType" = BIO_INCUBATOR_SLOT_FLEX,
+		"moduleType" = /datum/changeling_genetic_module/upgrade/neuro_sap,
 			"tags" = list("panacea", "chemicals"),
 			"exclusiveTags" = list("panacea"),
 			"button_icon_state" = "panacea",

--- a/code/modules/antagonists/changeling/passives/plasma_knit.dm
+++ b/code/modules/antagonists/changeling/passives/plasma_knit.dm
@@ -1,4 +1,10 @@
 /// Upgrade: Plasma Knit — saturates Fleshmend with tajaran scar-knitting, giant spider silk, and sheep clotting gel that lingers longer and knits faster.
+/datum/changeling_genetic_module/upgrade/plasma_knit
+	passive_effects = list(
+		"fleshmend_duration_add" = 6 SECONDS,
+		"fleshmend_heal_mult" = 1.4,
+	)
+
 /datum/changeling_genetic_matrix_recipe/plasma_knit
 	id = "matrix_plasma_knit"
 	name = "Plasma Knit"
@@ -9,6 +15,7 @@
 		"desc" = "Extends Fleshmend's duration and amplifies each restorative pulse.",
 		"category" = GENETIC_MATRIX_CATEGORY_UPGRADE,
 		"slotType" = BIO_INCUBATOR_SLOT_FLEX,
+		"moduleType" = /datum/changeling_genetic_module/upgrade/plasma_knit,
 		"tags" = list("healing", "support"),
 		"exclusiveTags" = list("fleshmend_upgrade"),
 		"button_icon_state" = "fleshmend",

--- a/code/modules/antagonists/changeling/passives/precise_barbs.dm
+++ b/code/modules/antagonists/changeling/passives/precise_barbs.dm
@@ -1,4 +1,10 @@
 /// Upgrade: Precise Barbs — tempers our musculature with vulpkanin pursuit sinew, nabber hunting hooks, and rabbit sprint cords for relentless pursuit.
+/datum/changeling_genetic_module/upgrade/precise_barbs
+	passive_effects = list(
+		"stamina_use_mult" = 0.8,
+		"chem_recharge_rate_add" = 0.4,
+	)
+
 /datum/changeling_genetic_matrix_recipe/precise_barbs
 	id = "matrix_precise_barbs"
 	name = "Precise Barbs"
@@ -9,6 +15,7 @@
 		"desc" = "Reduces exertion costs and bolsters chem flow for extended hunts.",
 		"category" = GENETIC_MATRIX_CATEGORY_UPGRADE,
 		"slotType" = BIO_INCUBATOR_SLOT_FLEX,
+		"moduleType" = /datum/changeling_genetic_module/upgrade/precise_barbs,
 		"tags" = list("mobility", "sustain"),
 		"exclusiveTags" = list("endurance_upgrade"),
 		"button_icon_state" = "strained_muscles",

--- a/code/modules/antagonists/changeling/passives/predator_sinew.dm
+++ b/code/modules/antagonists/changeling/passives/predator_sinew.dm
@@ -1,4 +1,7 @@
 /// Upgrade: Predator's Sinew — fuses tajaran pounce fibers, space carp launch fins, and fox pack tendons to steady Strained Muscles with a reactive tackle.
+/datum/changeling_genetic_module/upgrade/predator_sinew
+	passive_effects = list()
+
 /datum/changeling_genetic_matrix_recipe/predator_sinew
 	id = "matrix_predator_sinew"
 	name = "Predator's Sinew"
@@ -9,6 +12,7 @@
 		"desc" = "Reduces stamina backlash from Strained Muscles and adds a short sprint on activation.",
 		"category" = GENETIC_MATRIX_CATEGORY_UPGRADE,
 		"slotType" = BIO_INCUBATOR_SLOT_FLEX,
+		"moduleType" = /datum/changeling_genetic_module/upgrade/predator_sinew,
 		"tags" = list("mobility", "strength"),
 		"exclusiveTags" = list("mobility"),
 		"button_icon_state" = "strained_muscles",

--- a/code/modules/antagonists/changeling/passives/predatory_howl.dm
+++ b/code/modules/antagonists/changeling/passives/predatory_howl.dm
@@ -1,4 +1,7 @@
 /// Passive: Predatory Howl — refines the dissonant shriek with vulpkanin hunting howls, nightmare shadow lungs, and corgi pack calls into an execution note that ruptures skulls and machinery alike.
+/datum/changeling_genetic_module/key/predatory_howl
+	passive_effects = list()
+
 /datum/changeling_genetic_matrix_recipe/predatory_howl
 	id = "matrix_predatory_howl"
 	name = "Predatory Howl"
@@ -10,6 +13,7 @@
 		"helptext" = "Stacks with resonant shriek bonuses; incompatible with other key actives.",
 		"category" = GENETIC_MATRIX_CATEGORY_KEY,
 		"slotType" = BIO_INCUBATOR_SLOT_KEY,
+		"moduleType" = /datum/changeling_genetic_module/key/predatory_howl,
 		"tags" = list("sonic", "offense"),
 		"exclusiveTags" = list("key_active"),
 		"button_icon_state" = "dissonant_shriek",

--- a/code/modules/antagonists/changeling/passives/spore_node.dm
+++ b/code/modules/antagonists/changeling/passives/spore_node.dm
@@ -1,5 +1,8 @@
 
 /// Key Active: Spore Node — plants a pheromone sensor node spun from slimeperson gel, bee swarm instincts, and mothroach lattice that can be detonated into restraining spores.
+/datum/changeling_genetic_module/key/spore_node
+	passive_effects = list()
+
 /datum/changeling_genetic_matrix_recipe/spore_node
 	id = "matrix_spore_node"
 	name = "Spore Node"
@@ -11,6 +14,7 @@
 			"helptext" = "Only one node may exist at a time. Re-activating the ability detonates the current node.",
 			"category" = GENETIC_MATRIX_CATEGORY_KEY,
 			"slotType" = BIO_INCUBATOR_SLOT_KEY,
+		"moduleType" = /datum/changeling_genetic_module/key/spore_node,
 			"tags" = list("utility", "control"),
 			"exclusiveTags" = list("key_active"),
 	)

--- a/code/modules/antagonists/changeling/passives/symbiotic_overgrowth.dm
+++ b/code/modules/antagonists/changeling/passives/symbiotic_overgrowth.dm
@@ -1,4 +1,7 @@
 /// Passive: Symbiotic Overgrowth — cultivates human scar meshes, goat stamina fibers, and sheep mitotic layers that regenerate slowly and prime Regenerate for deeper healing bursts.
+/datum/changeling_genetic_module/passive/symbiotic_overgrowth
+	passive_effects = list()
+
 /datum/changeling_genetic_matrix_recipe/symbiotic_overgrowth
 	id = "matrix_symbiotic_overgrowth"
 	name = "Symbiotic Overgrowth"
@@ -9,6 +12,7 @@
 		"desc" = "Grants a slow baseline regeneration and improves the potency of the Regenerate ability.",
 		"category" = GENETIC_MATRIX_CATEGORY_PASSIVE,
 		"slotType" = BIO_INCUBATOR_SLOT_FLEX,
+		"moduleType" = /datum/changeling_genetic_module/passive/symbiotic_overgrowth,
 		"tags" = list("healing", "sustain"),
 		"exclusiveTags" = list("healing"),
 		"button_icon_state" = "regenerate",

--- a/code/modules/antagonists/changeling/passives/void_carapace.dm
+++ b/code/modules/antagonists/changeling/passives/void_carapace.dm
@@ -1,4 +1,7 @@
 /// Passive: Void Carapace — condenses teshari void instincts, goliath stone plates, and watcher frost cores into armor that surges during hazard exposure.
+/datum/changeling_genetic_module/passive/void_carapace
+	passive_effects = list()
+
 /datum/changeling_genetic_matrix_recipe/void_carapace
 	id = "matrix_void_carapace"
 	name = "Void Carapace"
@@ -9,6 +12,7 @@
 		"desc" = "Improves Void Adaption by shortening its chem slowdown, expanding hazard senses, and granting broader immunity.",
 		"category" = GENETIC_MATRIX_CATEGORY_PASSIVE,
 		"slotType" = BIO_INCUBATOR_SLOT_FLEX,
+		"moduleType" = /datum/changeling_genetic_module/passive/void_carapace,
 		"tags" = list("environment", "defense"),
 		"exclusiveTags" = list("adaptation"),
 		"button_icon_state" = null,


### PR DESCRIPTION
## Summary
- add module type support to genetic matrix recipe data and record module paths globally when recipes are registered
- define module datums for every changeling passive/upgrade/key module and plumb moduleType metadata into their recipes while preserving UI effect lists

## Testing
- ./tools/dm.sh *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68d59f10762c83308a40667003775d93