### PR TITLE
Refactor changeling bio incubator active module handling

### DIFF
--- a/code/modules/antagonists/changeling/genetic_matrix.dm
+++ b/code/modules/antagonists/changeling/genetic_matrix.dm
@@ -29,7 +29,7 @@
 		UnregisterSignal(listened_incubator, COMSIG_CHANGELING_BIO_INCUBATOR_UPDATED)
 		listened_incubator = null
 
-/datum/genetic_matrix/proc/on_bio_incubator_updated(datum/changeling_bio_incubator/incubator, update_flags)
+/datum/genetic_matrix/proc/on_bio_incubator_updated(datum/changeling_bio_incubator/incubator, update_flags, list/module_changes)
 	SIGNAL_HANDLER
 	if(QDELETED(src))
 		return


### PR DESCRIPTION
## Summary
- track active genetic modules as instantiated datums with helper procs, proper activation/deactivation, and owner assignment
- store module type metadata on registration, instantiate missing modules when applying builds, and emit activation change payloads
- derive build/module serialization (active flags, slots) from live instances while keeping UI payload compatibility

## Testing
- python3 tools/validate_dme.py *(hangs waiting for stdin; interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68d5a44c647483308b8eece65bb7e73b