### PR TITLE
Fix changeling module power lookup and trait cleanup

### DIFF
--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -356,6 +356,25 @@
 /datum/antagonist/changeling/proc/get_genetic_matrix_effect(effect_key, default_value)
 	return module_manager?.get_genetic_matrix_effect(effect_key, default_value)
 
+/datum/antagonist/changeling/proc/get_changeling_power_instance(power_path)
+	if(!ispath(power_path, /datum/action/changeling))
+		CRASH("Changeling get_changeling_power_instance attempted to access an invalid typepath! (got: [power_path])")
+
+	for(var/datum/action/changeling/innate as anything in innate_powers)
+		if(istype(innate, power_path))
+			return innate
+
+	var/datum/action/changeling/power = purchased_powers[power_path]
+	if(istype(power))
+		return power
+
+	for(var/purchased_path in purchased_powers)
+		var/datum/action/changeling/purchased_power = purchased_powers[purchased_path]
+		if(istype(purchased_power, power_path))
+			return purchased_power
+
+	return null
+
 /datum/antagonist/changeling/proc/on_matrix_module_activated(datum/changeling_genetic_module/module)
 	return
 

--- a/code/modules/antagonists/changeling/modules/passive/abyssal_slip.dm
+++ b/code/modules/antagonists/changeling/modules/passive/abyssal_slip.dm
@@ -38,7 +38,7 @@
 
 /datum/changeling_genetic_module/passive/abyssal_slip/on_deactivate()
 	unbind_host()
-	remove_traits()
+	remove_module_traits()
 	return ..()
 
 /datum/changeling_genetic_module/passive/abyssal_slip/on_owner_changed(mob/living/old_holder, mob/living/new_holder)
@@ -48,7 +48,7 @@
 	if(new_holder)
 		bind_host(new_holder)
 	else
-		remove_traits()
+		remove_module_traits()
 
 /datum/changeling_genetic_module/passive/abyssal_slip/proc/bind_host(mob/living/new_holder)
 	if(bound_host == new_holder)
@@ -72,7 +72,7 @@
 		return
 	living_owner.add_traits(list(TRAIT_SILENT_FOOTSTEPS, TRAIT_LIGHT_STEP), CHANGELING_TRAIT)
 
-/datum/changeling_genetic_module/passive/abyssal_slip/proc/remove_traits()
+/datum/changeling_genetic_module/passive/abyssal_slip/proc/remove_module_traits()
 	var/mob/living/living_owner = get_owner_mob()
 	if(!living_owner)
 		return

--- a/code/modules/antagonists/changeling/modules/passive/aether_drake_mantle.dm
+++ b/code/modules/antagonists/changeling/modules/passive/aether_drake_mantle.dm
@@ -44,7 +44,7 @@
 
 /datum/changeling_genetic_module/passive/aether_drake_mantle/on_deactivate()
 	revoke_action()
-	remove_traits()
+	remove_module_traits()
 	sync_void_adaption()
 	return ..()
 
@@ -55,7 +55,7 @@
 		apply_traits()
 	else
 		revoke_action()
-		remove_traits()
+		remove_module_traits()
 	sync_void_adaption()
 
 /datum/changeling_genetic_module/passive/aether_drake_mantle/proc/ensure_action()
@@ -79,7 +79,7 @@
 	living_owner.add_traits(list(TRAIT_SPACEWALK, TRAIT_FREE_HYPERSPACE_MOVEMENT), CHANGELING_TRAIT)
 	traits_applied = TRUE
 
-/datum/changeling_genetic_module/passive/aether_drake_mantle/proc/remove_traits()
+/datum/changeling_genetic_module/passive/aether_drake_mantle/proc/remove_module_traits()
 	if(!traits_applied)
 		return
 	var/mob/living/living_owner = get_owner_mob()


### PR DESCRIPTION
## Summary
- add a helper on the changeling antagonist datum to safely retrieve power instances for modules
- rename module-specific trait removal procs to avoid collisions with the shared /datum implementation

## Testing
- not run (DM compiler not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68d6bd2ef85483308fe0166360dc2fd9