### PR TITLE
Fix genetic matrix save button state

### DIFF
--- a/tgui/packages/tgui/interfaces/GeneticMatrix.tsx
+++ b/tgui/packages/tgui/interfaces/GeneticMatrix.tsx
@@ -448,10 +448,8 @@ const MatrixTab = ({
     );
   }, [selectedBuild]);
 
-  const hasPendingChanges = useMemo(() => {
-    if (!selectedBuild) {
-      return false;
-    }
+  let hasPendingChanges = false;
+  if (selectedBuild) {
     const modulesList = selectedBuild.modules ?? [];
     const activeIds = selectedBuild.activeModuleIds ?? [];
     const slotCount = Math.max(maxModuleSlots, modulesList.length, activeIds.length);
@@ -459,11 +457,11 @@ const MatrixTab = ({
       const assignedId = modulesList[index]?.id ?? null;
       const activeId = activeIds[index] ?? null;
       if (assignedId !== activeId) {
-        return true;
+        hasPendingChanges = true;
+        break;
       }
     }
-    return false;
-  }, [maxModuleSlots, selectedBuild]);
+  }
 
   const commitDisabledReason = !selectedBuild
     ? 'We lack a genetic configuration to edit.'


### PR DESCRIPTION
## Summary
- ensure the genetic matrix UI recomputes pending change detection when modules are reassigned so the save button enables correctly

## Testing
- npm run tgui:lint *(fails: pre-existing lint issues in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d6ddd4e0348330a7399e2dcdf58c1a