### PR TITLE
Fix pending module detection in genetic matrix UI

### DIFF
--- a/tgui/packages/tgui/interfaces/GeneticMatrix.tsx
+++ b/tgui/packages/tgui/interfaces/GeneticMatrix.tsx
@@ -477,9 +477,14 @@ const MatrixTab = ({
     const activeIds = selectedBuildActiveIds;
     const slotCount = Math.max(maxModuleSlots, modulesList.length, activeIds.length);
     for (let index = 0; index < slotCount; index += 1) {
-      const assignedId = modulesList[index]?.id ?? null;
+      const moduleEntry = modulesList[index] ?? null;
+      const assignedId = moduleEntry?.id ?? null;
       const activeId = activeIds[index] ?? null;
-      if (assignedId !== activeId) {
+      const pendingAssignment = Boolean(
+        moduleEntry && moduleEntry.active !== undefined && !asBoolean(moduleEntry.active),
+      );
+      const pendingRemoval = !moduleEntry && Boolean(activeId);
+      if (assignedId !== activeId || pendingAssignment || pendingRemoval) {
         hasPendingChanges = true;
         break;
       }


### PR DESCRIPTION
## Summary
- ensure the genetic matrix UI recognizes unsaved module changes
- account for pending module assignments and removals when enabling the save action

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6e7635aac833093b1f6eca149e334