### PR TITLE
Fix genetic matrix save button not enabling after module changes

### DIFF
--- a/tgui/packages/tgui/interfaces/GeneticMatrix.tsx
+++ b/tgui/packages/tgui/interfaces/GeneticMatrix.tsx
@@ -456,7 +456,11 @@ const MatrixTab = ({
     const activeIds = selectedBuild.activeModuleIds ?? [];
     const slotCount = Math.max(maxModuleSlots, modulesList.length, activeIds.length);
     for (let index = 0; index < slotCount; index += 1) {
-      const assignedId = modulesList[index]?.id ?? null;
+      const moduleEntry = modulesList[index] ?? null;
+      if (moduleEntry?.active === false) {
+        return true;
+      }
+      const assignedId = moduleEntry?.id ?? null;
       const activeId = activeIds[index] ?? null;
       if (assignedId !== activeId) {
         return true;


### PR DESCRIPTION
## Summary
- ensure the genetic matrix interface detects pending module changes using the module entry active flag
- keep the save configuration button enabled whenever any slot has unsaved updates

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6f20be1888330a0ca261651ae0d6e