### PR TITLE
Fix genetic matrix module status reporting

### DIFF
--- a/code/modules/antagonists/changeling/bio_incubator.dm
+++ b/code/modules/antagonists/changeling/bio_incubator.dm
@@ -328,8 +328,12 @@
 				var/found_slot = active_instances.Find(module)
 				if(found_slot)
 					slot_index = found_slot
-		copy["active"] = !isnull(slot_index)
-		copy["slot"] = slot_index
+		if(!isnull(slot_index))
+			copy["slot"] = slot_index
+			copy["active"] = TRUE
+		else
+			copy -= "slot"
+			copy -= "active"
 		catalog += list(copy)
 	return catalog
 


### PR DESCRIPTION
## Summary
- avoid marking crafted changeling genetic modules as pending when they are not active in any slot
- only report slot and active status metadata for modules that are actually equipped

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6fc6a7ee483309869ff34dee08e31