### PR TITLE
Gate default build auto application

### DIFF
--- a/code/modules/antagonists/changeling/bio_incubator.dm
+++ b/code/modules/antagonists/changeling/bio_incubator.dm
@@ -59,8 +59,9 @@
 /datum/changeling_bio_incubator/proc/can_add_build()
 	return builds.len < get_max_builds()
 
-/datum/changeling_bio_incubator/proc/ensure_default_build()
+/datum/changeling_bio_incubator/proc/ensure_default_build(apply_configuration = FALSE)
 	var/changed = FALSE
+	var/should_apply_configuration = apply_configuration
 	if(builds.len > 1)
 		for(var/i in 2 to builds.len)
 			var/datum/changeling_bio_incubator/build/extra = builds[i]
@@ -75,17 +76,12 @@
 		build.ensure_slot_capacity()
 		builds += list(build)
 		changed = TRUE
+		should_apply_configuration = TRUE
 	var/datum/changeling_bio_incubator/build/primary = builds[1]
 	if(primary)
 		primary.ensure_slot_capacity()
 	ensure_active_capacity()
-	var/has_active_modules = FALSE
-	for(var/datum/changeling_genetic_module/module as anything in active_modules)
-		if(!module)
-			continue
-		has_active_modules = TRUE
-		break
-	if(!has_active_modules)
+	if(should_apply_configuration && primary)
 		apply_build_configuration(primary, notify = FALSE)
 	else
 		sanitize_active_modules()

--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -254,7 +254,7 @@
 	QDEL_NULL(bio_incubator)
 	bio_incubator = new(src)
 	module_manager?.set_bio_incubator(bio_incubator)
-	bio_incubator.ensure_default_build()
+	bio_incubator.ensure_default_build(apply_configuration = TRUE)
 	update_genetic_matrix_unlocks()
 	if(genetic_matrix)
 		genetic_matrix.register_with_incubator()


### PR DESCRIPTION
## Summary
- add an optional apply flag to `ensure_default_build` so routine refreshes no longer reapply the active build
- request the initial application when creating a bio incubator so new changelings still receive their starting loadout

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d7b3b4d6a48330be20be85b8c55c70