### PR TITLE
Handle reactivating bio incubator modules

### DIFF
--- a/code/modules/antagonists/changeling/bio_incubator.dm
+++ b/code/modules/antagonists/changeling/bio_incubator.dm
@@ -472,7 +472,21 @@
 			continue
 		if(current)
 			current.assign_owner(changeling)
-			continue
+			if(current.is_active())
+				continue
+			var/reactivation_result = current.on_activate()
+			if(reactivation_result)
+				changed = TRUE
+				current.vars[CHANGELING_MODULE_ACTIVE_FLAG] = TRUE
+				if(current.id)
+					activated += list(list(
+					"id" = current.id,
+					"slot" = i,
+					))
+				continue
+			deactivate_module_instance(i, current, deactivated)
+			changed = TRUE
+			current = null
 		var/datum/changeling_genetic_module/new_module = create_module_instance(desired_id)
 		if(!new_module)
 			continue


### PR DESCRIPTION
## Summary
- ensure existing changeling modules are reactivated when applying a build configuration
- report reactivated modules through the payload so the UI refreshes correctly

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7edbec41483309c2dc18e856a5866