### PR TITLE
Adjust changeling module status handling

### DIFF
--- a/code/modules/antagonists/changeling/bio_incubator.dm
+++ b/code/modules/antagonists/changeling/bio_incubator.dm
@@ -324,8 +324,12 @@
 				var/found_slot = active_instances.Find(module)
 				if(found_slot)
 					slot_index = found_slot
-		copy["active"] = !isnull(slot_index)
-		copy["slot"] = slot_index
+		if(!isnull(slot_index))
+			copy["active"] = TRUE
+			copy["slot"] = slot_index
+		else
+			copy -= "active"
+			copy -= "slot"
 		catalog += list(copy)
 	return catalog
 

--- a/tgui/packages/tgui/interfaces/GeneticMatrix.tsx
+++ b/tgui/packages/tgui/interfaces/GeneticMatrix.tsx
@@ -1277,8 +1277,9 @@ type ModuleSummaryProps = {
 const ModuleSummary = ({ module, showSource = true, conflictTags = [] }: ModuleSummaryProps) => {
   const sourceLabel = showSource ? formatSource(module.source) : '';
   const sourceColor = module.source?.toLowerCase() === 'innate' ? 'good' : 'average';
-  const statusDefined = module.active !== undefined;
-  const isActive = statusDefined ? asBoolean(module.active) : false;
+  const statusValue = module.active;
+  const statusDefined = statusValue !== undefined && statusValue !== null;
+  const isActive = statusDefined ? asBoolean(statusValue) : false;
   const statusLabel = statusDefined ? (isActive ? 'Equipped' : 'Pending Save') : '';
   const statusColor = isActive ? 'good' : 'average';
   return (


### PR DESCRIPTION
## Summary
- avoid reporting a status for crafted changeling modules that are not actually active
- treat missing module activity flags in the genetic matrix UI as stored modules with no status text

## Testing
- Not run (not available in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68d80bad3ef08330b7238c2ec1fc256f