### PR TITLE
Use dedicated do_after key for changeling matrix reconfiguration

### DIFF
--- a/code/__DEFINES/do_afters.dm
+++ b/code/__DEFINES/do_afters.dm
@@ -9,3 +9,4 @@
 #define DOAFTER_SOURCE_CHARGE_CRANKRECHARGE "doafter_charge_crank_recharge"
 #define DOAFTER_SOURCE_REMOVING_HOOK "doafter_removing_hook"
 #define DOAFTER_SOURCE_CHARGING_ESWORD "doafter_charging_esword"
+#define DOAFTER_SOURCE_CHANGELING_MATRIX "doafter_changeling_matrix"

--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -308,7 +308,7 @@
 	if(genetic_matrix)
 		SStgui.update_uis(genetic_matrix)
 	to_chat(living_owner, span_notice("We focus inward, preparing to rewrite our genome."))
-	if(!do_after(living_owner, 15 SECONDS, living_owner))
+       if(!do_after(living_owner, 15 SECONDS, target = living_owner, interaction_key = DOAFTER_SOURCE_CHANGELING_MATRIX, max_interact_count = 1))
 		genetic_matrix_reconfiguring = FALSE
 		if(genetic_matrix)
 			SStgui.update_uis(genetic_matrix)


### PR DESCRIPTION
## Summary
- add a dedicated do_after interaction key for changeling genetic matrix saving so other self interactions no longer cancel it
- define DOAFTER_SOURCE_CHANGELING_MATRIX for the new interaction key

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d80db9ebcc8330a44e88d54fec297d