### PR TITLE
Fix changeling genetic matrix indentation

### DIFF
--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -308,7 +308,7 @@
 	if(genetic_matrix)
 		SStgui.update_uis(genetic_matrix)
 	to_chat(living_owner, span_notice("We focus inward, preparing to rewrite our genome."))
-		if(!do_after(living_owner, 15 SECONDS, target = living_owner, interaction_key = DOAFTER_SOURCE_CHANGELING_MATRIX, max_interact_count = 1))
+	if(!do_after(living_owner, 15 SECONDS, target = living_owner, interaction_key = DOAFTER_SOURCE_CHANGELING_MATRIX, max_interact_count = 1))
 		genetic_matrix_reconfiguring = FALSE
 		if(genetic_matrix)
 			SStgui.update_uis(genetic_matrix)


### PR DESCRIPTION
## Summary
- fix the indentation of the do_after interruption check in the changeling genetic matrix configuration proc
- ensure the early return block is scoped correctly to avoid compile failures

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d813ce68408330bae96b205cb7d0c3