### PR TITLE
Fix changeling module activation flag handling

### DIFF
--- a/code/modules/antagonists/changeling/bio_incubator.dm
+++ b/code/modules/antagonists/changeling/bio_incubator.dm
@@ -494,38 +494,54 @@
 			current = null
 		if(!desired_id)
 			continue
-		if(current)
-			current.assign_owner(changeling)
-			if(current.is_active())
-				continue
-			var/reactivation_result = current.on_activate()
-			if(reactivation_result)
-				changed = TRUE
+			if(current)
+				current.assign_owner(changeling)
 				current.vars[CHANGELING_MODULE_ACTIVE_FLAG] = TRUE
-				if(current.id)
-					activated += list(list(
-					"id" = current.id,
-					"slot" = i,
+				if(current.is_active())
+					continue
+				var/reactivation_result = current.on_activate()
+				if(reactivation_result)
+					changed = TRUE
+					if(current.id)
+						activated += list(list(
+							"id" = current.id,
+							"slot" = i,
+						))
+					continue
+				current.on_deactivate()
+				current.vars[CHANGELING_MODULE_ACTIVE_FLAG] = FALSE
+				current.assign_owner(null)
+				if(active_modules.len >= i && active_modules[i] == current)
+					active_modules[i] = null
+				if(islist(deactivated) && current.id)
+					deactivated += list(list(
+						"id" = current.id,
+						"slot" = i,
 					))
+				qdel(current)
+				changed = TRUE
+				current = null
+			var/datum/changeling_genetic_module/new_module = create_module_instance(desired_id)
+			if(!new_module)
 				continue
-			deactivate_module_instance(i, current, deactivated)
+			active_modules[i] = new_module
 			changed = TRUE
-			current = null
-		var/datum/changeling_genetic_module/new_module = create_module_instance(desired_id)
-		if(!new_module)
-			continue
-		active_modules[i] = new_module
-		changed = TRUE
-		var/activation_result = new_module.on_activate()
-		if(!activation_result)
-			deactivate_module_instance(i, new_module)
-			continue
-		new_module.vars[CHANGELING_MODULE_ACTIVE_FLAG] = TRUE
-		if(new_module.id)
-			activated += list(list(
-				"id" = new_module.id,
-				"slot" = i,
-			))
+			new_module.assign_owner(changeling)
+			new_module.vars[CHANGELING_MODULE_ACTIVE_FLAG] = TRUE
+			var/activation_result = new_module.on_activate()
+			if(!activation_result)
+				new_module.on_deactivate()
+				new_module.vars[CHANGELING_MODULE_ACTIVE_FLAG] = FALSE
+				new_module.assign_owner(null)
+				if(active_modules.len >= i && active_modules[i] == new_module)
+					active_modules[i] = null
+				qdel(new_module)
+				continue
+			if(new_module.id)
+				activated += list(list(
+					"id" = new_module.id,
+					"slot" = i,
+				))
 	var/list/module_changes = build_module_change_payload(activated, deactivated)
 	if(changed && notify)
 		notify_update(BIO_INCUBATOR_UPDATE_BUILDS, module_changes)


### PR DESCRIPTION
## Summary
- set changeling modules to the correct owner and active flag before running activation hooks
- ensure failed activations clean up ownership and active markers before the module is discarded

## Testing
- `bash tools/ci/check_grep.sh` *(fails: existing lowertext() usage in code/modules/antagonists/changeling/cell_registry.dm)*

------
https://chatgpt.com/codex/tasks/task_e_68d857f36e5c8330ac25cc5850e4e4af