### PR TITLE
Improve changeling spore node utility

### DIFF
--- a/code/modules/antagonists/changeling/powers/spore_node.dm
+++ b/code/modules/antagonists/changeling/powers/spore_node.dm
@@ -63,6 +63,18 @@
 	var/datum/weakref/changeling_ref
 	/// Tracks recently pinged mobs to avoid spam.
 	var/list/tracked_refs = list()
+	/// Cached owner receiving passive buffs.
+	var/datum/weakref/buffed_owner_ref
+	/// Whether the passive buffs are currently applied.
+	var/passive_buffs_active = FALSE
+	/// Maximum distance in tiles to grant passive buffs.
+	var/passive_buff_range = 5
+	/// Additional maximum stamina granted while in range.
+	var/passive_buff_max_stamina = 10
+	/// Multiplier applied to stamina regeneration delay (lower is faster).
+	var/passive_buff_regen_mult = 0.85
+	/// Additional changeling chemical recharge granted while in range.
+	var/passive_buff_chem_rate = 0.3
 
 /obj/structure/changeling_spore_node/Initialize(mapload, datum/antagonist/changeling/changeling_data)
 	. = ..()
@@ -74,6 +86,7 @@
 /obj/structure/changeling_spore_node/Destroy()
 	STOP_PROCESSING(SSobj, src)
 	tracked_refs.Cut()
+	remove_passive_buffs()
 	var/datum/antagonist/changeling/changeling_data = changeling_ref?.resolve()
 	changeling_data?.clear_spore_node(src)
 	changeling_ref = null
@@ -84,12 +97,22 @@
 	if(!changeling_data || changeling_data.owner?.current?.stat == DEAD)
 		qdel(src)
 		return
+	var/mob/living/owner = changeling_data.owner?.current
+	var/buffs_should_apply = FALSE
+	if(istype(owner) && owner.stat < DEAD)
+		var/turf/owner_turf = get_turf(owner)
+		if(owner_turf && get_dist(owner_turf, src) <= passive_buff_range)
+			buffs_should_apply = TRUE
+	if(buffs_should_apply)
+		apply_passive_buffs(owner, changeling_data)
+	else
+		remove_passive_buffs(changeling_data)
 	var/list/current_refs = list()
 	for(var/mob/living/victim in range(2, src))
 		if(IS_CHANGELING(victim) || victim.stat == DEAD)
 			continue
 		var/datum/weakref/ref = WEAKREF(victim)
-		current_refs += ref
+		current_refs[ref] = TRUE
 		if(tracked_refs[ref])
 			continue
 		notify_changeling(victim)
@@ -116,8 +139,40 @@
 		if(target.stat == DEAD || IS_CHANGELING(target))
 			continue
 		target.adjustStaminaLoss(40)
-		target.Knockdown(2 SECONDS)
+		target.Knockdown(4 SECONDS)
 		target.apply_status_effect(/datum/status_effect/dazed, 6 SECONDS)
 	qdel(src)
 	var/datum/antagonist/changeling/changeling_data = changeling_ref?.resolve()
 	changeling_data?.spore_node_detonated(user)
+
+/obj/structure/changeling_spore_node/proc/apply_passive_buffs(mob/living/owner, datum/antagonist/changeling/changeling_data)
+	if(!istype(owner) || !changeling_data)
+		return
+	if(passive_buffs_active)
+		var/mob/living/current_buff_target = buffed_owner_ref?.resolve()
+		if(current_buff_target == owner)
+			return
+		remove_passive_buffs(changeling_data)
+	if(owner.stat >= DEAD)
+		return
+	owner.max_stamina += passive_buff_max_stamina
+	owner.staminaloss = clamp(owner.staminaloss, 0, owner.max_stamina)
+	owner.stamina_regen_time *= passive_buff_regen_mult
+	changeling_data.chem_recharge_rate += passive_buff_chem_rate
+	passive_buffs_active = TRUE
+	buffed_owner_ref = WEAKREF(owner)
+
+/obj/structure/changeling_spore_node/proc/remove_passive_buffs(datum/antagonist/changeling/changeling_data)
+	if(!passive_buffs_active)
+		return
+	if(!changeling_data)
+		changeling_data = changeling_ref?.resolve()
+	var/mob/living/buffed_owner = buffed_owner_ref?.resolve()
+	if(istype(buffed_owner))
+		buffed_owner.max_stamina = max(buffed_owner.max_stamina - passive_buff_max_stamina, 0)
+		buffed_owner.staminaloss = clamp(buffed_owner.staminaloss, 0, buffed_owner.max_stamina)
+		if(passive_buff_regen_mult)
+			buffed_owner.stamina_regen_time /= passive_buff_regen_mult
+	changeling_data?.chem_recharge_rate -= passive_buff_chem_rate
+	passive_buffs_active = FALSE
+	buffed_owner_ref = null


### PR DESCRIPTION
## Summary
- fix changeling spore node tracking so nearby enemies reliably ping the owner without repeated spam
- grant the changeling passive stamina and chemical regeneration buffs while within range of their spore node
- increase the spore burst knockdown duration to keep victims snared for longer when the node is detonated
- normalize indentation in the spore node implementation to match project style

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d9a86f2f9c832eb3ab73b63b73b96a