### PR TITLE
Buff changeling barbed larynx matrix passive

### DIFF
--- a/code/modules/antagonists/changeling/matrix_recipes/passive/barbed_larynx.dm
+++ b/code/modules/antagonists/changeling/matrix_recipes/passive/barbed_larynx.dm
@@ -6,15 +6,15 @@
 	module = list(
 		"id" = "matrix_barbed_larynx",
 		"name" = "Barbed Larynx",
-		"desc" = "Bolsters our sonic shrieks with broader reach and lingering vertigo.",
+		"desc" = "Bolsters our sonic shrieks with sweeping reach and crushing vertigo.",
 		"category" = GENETIC_MATRIX_CATEGORY_PASSIVE,
 		"slotType" = BIO_INCUBATOR_SLOT_FLEX,
 		"tags" = list("sonic", "crowd_control"),
 		"exclusiveTags" = list("shriek_range"),
 		"button_icon_state" = "resonant_shriek",
 		"effects" = list(
-			"resonant_shriek_range_add" = 2,
-			"resonant_shriek_confusion_mult" = 1.1,
+			"resonant_shriek_range_add" = 3,
+			"resonant_shriek_confusion_mult" = 1.3,
 		),
 	)
 	required_cells = list(


### PR DESCRIPTION
## Summary
- increase the Barbed Larynx matrix passive's resonant shriek range bonus to 3 tiles
- raise the confusion multiplier to 1.3 and tweak the description to match the stronger effect

## Testing
- not run (not required)


------
https://chatgpt.com/codex/tasks/task_e_68d9ae9e4098832ea9b397691ebf0706