### PR TITLE
Fix changeling Ashen Pump fire protection

### DIFF
--- a/code/modules/antagonists/changeling/matrix_recipes/upgrade/ashen_pump.dm
+++ b/code/modules/antagonists/changeling/matrix_recipes/upgrade/ashen_pump.dm
@@ -45,6 +45,10 @@
 /datum/status_effect/changeling_ashen_pump/on_remove()
 	UnregisterSignal(owner, COMSIG_MOVABLE_MOVED)
 	remove_burn_bonus()
+	if(isliving(owner))
+		var/mob/living/living_owner = owner
+		living_owner.set_fire_stacks(0, remove_wet_stacks = FALSE)
+		living_owner.extinguish_mob()
 	return ..()
 
 /datum/status_effect/changeling_ashen_pump/tick(seconds_between_ticks)
@@ -65,7 +69,10 @@
 		new /obj/effect/hotspot(T)
 	T.hotspot_expose(900, 50, 1)
 	if(owner in T)
-		owner.extinguish_mob()
+		if(isliving(owner))
+			var/mob/living/living_owner = owner
+			living_owner.set_fire_stacks(0, remove_wet_stacks = FALSE)
+			living_owner.extinguish_mob()
 	for(var/mob/living/carbon/victim in T)
 		if(victim == owner || IS_CHANGELING(victim))
 			continue

--- a/code/modules/antagonists/changeling/powers/adrenaline.dm
+++ b/code/modules/antagonists/changeling/powers/adrenaline.dm
@@ -7,7 +7,7 @@
 	dna_cost = 2
 	req_human = FALSE
 	req_stat = CONSCIOUS
-	disabled_by_fire = TRUE
+	disabled_by_fire = FALSE
 
 //Recover from stuns.
 /datum/action/changeling/adrenaline/sting_action(mob/living/carbon/user)


### PR DESCRIPTION
## Summary
- prevent Ashen Pump's lingering flames from igniting the changeling by clearing fire stacks while the status effect is active and when it ends
- allow Gene Stim to be triggered even while the changeling is burning so Ashen Pump remains usable during fires

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d9bd583a28832eb8e2121f3fcb905c