### PR TITLE
Add acid resilience to changeling corrosive bile upgrade

### DIFF
--- a/code/modules/antagonists/changeling/matrix_recipes/upgrade/corrosive_bile.dm
+++ b/code/modules/antagonists/changeling/matrix_recipes/upgrade/corrosive_bile.dm
@@ -2,11 +2,11 @@
 /datum/changeling_genetic_matrix_recipe/corrosive_bile
 	id = "matrix_corrosive_bile"
 	name = "Corrosive Bile"
-	description = "Concentrate volatile bile streams from slimeperson acid bladders, morph solvent sacs, and giant spider venoms to chew through bindings almost instantly."
+	description = "Concentrate volatile bile streams from slimeperson acid bladders, morph solvent sacs, and giant spider venoms to chew through bindings almost instantly while hardening our flesh against splashback."
 	module = list(
 		"id" = "matrix_corrosive_bile",
 		"name" = "Corrosive Bile",
-		"desc" = "Speeds up Biodegrade reactions while shaving their chemical costs.",
+		"desc" = "Speeds up Biodegrade reactions while shaving their chemical costs and toughening us against caustic burns.",
 		"category" = GENETIC_MATRIX_CATEGORY_UPGRADE,
 		"slotType" = BIO_INCUBATOR_SLOT_FLEX,
 		"tags" = list("acid", "escape"),
@@ -15,6 +15,7 @@
 		"effects" = list(
 			"biodegrade_timer_mult" = 0.4,
 			"biodegrade_chem_discount" = 16,
+			"incoming_burn_damage_mult" = 0.9,
 		),
 	)
 	required_cells = list(


### PR DESCRIPTION
## Summary
- extend the Corrosive Bile upgrade descriptions to mention splashback protection
- grant the module a small passive reduction to incoming burn damage

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9c0df6724832ebe00c31383a0998e