### PR TITLE
Explicitly use tentacle beam asset for ripsaw grapple

### DIFF
--- a/code/modules/antagonists/changeling/core/changeling_matrix_manager.dm
+++ b/code/modules/antagonists/changeling/core/changeling_matrix_manager.dm
@@ -362,7 +362,8 @@
 	user.setDir(get_dir(user_turf, destination))
 	user.Beam(
 		destination,
-		icon_state = "zipline_hook",
+		icon = 'icons/effects/beam.dmi',
+		icon_state = "tentacle",
 		time = 0.5 SECONDS,
 		emissive = FALSE,
 		maxdistance = GRAVITON_RIPSAW_GRAPPLE_RANGE,


### PR DESCRIPTION
## Summary
- ensure the ripsaw grapple explicitly uses the tentacle beam icon asset so the tether renders as a thread

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d9c3b92bf0832e96285d5e34f5c529