### PR TITLE
Ensure ripsaw tether uses beam visuals

### DIFF
--- a/code/modules/antagonists/changeling/core/changeling_matrix_manager.dm
+++ b/code/modules/antagonists/changeling/core/changeling_matrix_manager.dm
@@ -362,11 +362,12 @@
 	user.setDir(get_dir(user_turf, destination))
 	user.Beam(
 		destination,
-		icon_state = "zipline_hook",
+		icon = 'icons/effects/beam.dmi',
+		icon_state = "tentacle",
 		time = 0.5 SECONDS,
 		emissive = FALSE,
 		maxdistance = GRAVITON_RIPSAW_GRAPPLE_RANGE,
-		layer = BELOW_MOB_LAYER
+		layer = BELOW_MOB_LAYER,
 	)
 	playsound(user, 'sound/effects/splat.ogg', 40, TRUE)
 	user.throw_at(destination, distance_to_destination, 1, user, spin = FALSE, gentle = TRUE)


### PR DESCRIPTION
## Summary
- explicitly render the changeling ripsaw grapple tether with the beam icon set used by tentacle threads

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d9c3b92bf0832e96285d5e34f5c529