### PR TITLE
Adjust aether burst balance and fix changeling icons

### DIFF
--- a/code/modules/antagonists/changeling/powers/aether_burst.dm
+++ b/code/modules/antagonists/changeling/powers/aether_burst.dm
@@ -1,10 +1,10 @@
 
 /datum/action/changeling/aether_burst
 	name = "Aetheric Burst"
-	desc = "We vent draconic plasma to shove ourselves through open space. Costs 2 chemicals."
+	desc = "We vent draconic plasma to shove ourselves through open space. Costs 8 chemicals."
 	helptext = "Requires the Aether Drake Mantle. Propels us a few tiles in the direction we face even in zero-g."
-	button_icon_state = "lesserform"
-	chemical_cost = 2
+	button_icon_state = "lesser_form"
+	chemical_cost = 8
 	dna_cost = CHANGELING_POWER_UNOBTAINABLE
 	req_stat = CONSCIOUS
 	disabled_by_fire = FALSE
@@ -12,7 +12,7 @@
 	/// Cooldown tracker in deciseconds.
 	var/next_allowed = 0
 	/// Minimum delay between bursts.
-	var/cooldown_length = 15
+	var/cooldown_length = 30
 
 /datum/action/changeling/aether_burst/sting_action(mob/living/user)
 	var/datum/antagonist/changeling/changeling_data = IS_CHANGELING(user)

--- a/code/modules/antagonists/changeling/powers/chitin_courier.dm
+++ b/code/modules/antagonists/changeling/powers/chitin_courier.dm
@@ -3,7 +3,7 @@
 	name = "Chitin Courier"
 	desc = "We unfurl a hidden cache beneath our skin for a single medium item."
 	helptext = "Store or retrieve a compact contraband item invisibly. Requires the Chitin Courier matrix passive."
-	button_icon_state = "lesserform"
+	button_icon_state = "lesser_form"
 	chemical_cost = 0
 	dna_cost = CHANGELING_POWER_UNOBTAINABLE
 	req_stat = CONSCIOUS


### PR DESCRIPTION
## Summary
- increase the Aetheric Burst chemical cost to 8 and lengthen its cooldown to make the mantle dash more taxing
- correct the action icon reference for both Aetheric Burst and Chitin Courier to remove error placeholders

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da4aa3f8dc832eba9a46d933bbee53